### PR TITLE
feat: add official plugin directory metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.1.2 — 2026-08-02
+
+### Changed
+
+- Added official plugin-directory icon metadata and brand color alongside the packaged
+  Astral Orchestrator logo.
+
 ## 3.1.1 — 2026-08-02
 
 ### Changed

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -21,7 +21,7 @@ recorded.
 ## Identity and migration
 
 Version 3.0.0 was the breaking identity migration from the former Project Pilot
-identifiers. The current product version is 3.1.1. The normalized plugin, marketplace,
+identifiers. The current product version is 3.1.2. The normalized plugin, marketplace,
 skill, and profile prefix is
 astral-orchestrator; TOML agent names use astral_orchestrator. Route evidence begins
 with ASTRAL_ORCHESTRATOR_ROUTE, and persistent effort settings live at

--- a/plugins/astral-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/astral-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "astral-orchestrator",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Beginner-friendly, model-routed orchestration for planning, delegating, verifying, and reviewing project work in Codex.",
   "author": {
     "name": "Demonbane18"
@@ -25,10 +25,13 @@
     "longDescription": "Astral Orchestrator turns an everyday request into a clear outcome, keeps the Sol model in charge, routes bounded work to pinned Luna or Terra models at their configured efforts, verifies the actual result, and uses a fresh Sol reviewer before handoff.",
     "developerName": "Astral Orchestrator Contributors",
     "category": "Productivity",
+    "brandColor": "#0B1020",
     "capabilities": [
       "Interactive",
       "Write"
     ],
+    "composerIcon": "./skills/astral-orchestrator/assets/icon.png",
+    "logo": "./skills/astral-orchestrator/assets/icon.png",
     "defaultPrompt": [
       "Use Astral Orchestrator to complete this request and verify the result.",
       "Use Astral Orchestrator in Quick mode for this small change.",

--- a/plugins/astral-orchestrator/scripts/verify.sh
+++ b/plugins/astral-orchestrator/scripts/verify.sh
@@ -45,8 +45,8 @@ manifest_path, skill_path, modes_path, templates_path, routing_path, agent_dir, 
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 if manifest.get("name") != "astral-orchestrator":
     raise SystemExit("manifest name must be astral-orchestrator")
-if manifest.get("version") != "3.1.1":
-    raise SystemExit("manifest version must be Astral Orchestrator v3.1.1")
+if manifest.get("version") != "3.1.2":
+    raise SystemExit("manifest version must be Astral Orchestrator v3.1.2")
 if manifest.get("skills") != "./skills/":
     raise SystemExit("manifest skills path must be ./skills/")
 if manifest.get("license") != "MIT":

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -64,7 +64,7 @@ class MarketplaceTests(unittest.TestCase):
         manifest = load_json(MANIFEST)
 
         self.assertEqual(manifest["name"], "astral-orchestrator")
-        self.assertEqual(manifest["version"], "3.1.1")
+        self.assertEqual(manifest["version"], "3.1.2")
         self.assertEqual(manifest["license"], "MIT")
         self.assertEqual(manifest["skills"], "./skills/")
         self.assertEqual(manifest["interface"]["displayName"], "Astral Orchestrator")


### PR DESCRIPTION
## Summary

- add OpenAI universal plugin-directory icon metadata
- include brand color and composer/logo paths for the Astral mark
- bump the package to v3.1.2 and align verifier/changelog checks

## Validation

- 33 unit tests passed
- repository verifier passed
- official Codex skill validator passed
- official Codex plugin validator passed