### PR TITLE
Release Astral Orchestrator v3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.3 — 2026-08-03
+
+### Fixed
+
+- Included the canonical MIT `LICENSE` and Sol Advisor `NOTICE.md` attribution in the
+  distributable plugin bundle.
+- Added package verification and regression coverage that reject missing or modified
+  distributable notices.
+
 ## 3.1.2 — 2026-08-02
 
 ### Changed

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -21,7 +21,7 @@ recorded.
 ## Identity and migration
 
 Version 3.0.0 was the breaking identity migration from the former Project Pilot
-identifiers. The current product version is 3.1.2. The normalized plugin, marketplace,
+identifiers. The current product version is 3.1.3. The normalized plugin, marketplace,
 skill, and profile prefix is
 astral-orchestrator; TOML agent names use astral_orchestrator. Route evidence begins
 with ASTRAL_ORCHESTRATOR_ROUTE, and persistent effort settings live at

--- a/plugins/astral-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/astral-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "astral-orchestrator",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Beginner-friendly, model-routed orchestration for planning, delegating, verifying, and reviewing project work in Codex.",
   "author": {
     "name": "Demonbane18"

--- a/plugins/astral-orchestrator/LICENSE
+++ b/plugins/astral-orchestrator/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Daniel McAteer
+Copyright (c) 2026 Astral Orchestrator Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/astral-orchestrator/NOTICE.md
+++ b/plugins/astral-orchestrator/NOTICE.md
@@ -1,0 +1,17 @@
+# Attribution
+
+Astral Orchestrator is an independent, beginner-oriented adaptation inspired by
+[DannyMac180/sol-advisor](https://github.com/DannyMac180/sol-advisor), reviewed at
+commit 92f0fb105854e0fa606bdc98bfe688411e1db989.
+
+Sol Advisor is copyright © 2026 Daniel McAteer and distributed under the MIT License.
+Its original copyright and permission notice are preserved in this repository's LICENSE.
+
+Astral Orchestrator v3 retains the architect → implementation → verification → fresh
+review pattern and adapts Sol Advisor's model-specific routing, companion-profile
+installation, and allowlisted runtime inspection. It adds Quick, Guided, and Careful
+modes, namespaced profiles, conflict-safe removal, configurable effort settings, and a
+Python standard-library inspector for a broader audience.
+
+Astral Orchestrator is not endorsed by or affiliated with Daniel McAteer. See
+[docs/IMPROVEMENTS.md](docs/IMPROVEMENTS.md) for the design comparison.

--- a/plugins/astral-orchestrator/scripts/verify.sh
+++ b/plugins/astral-orchestrator/scripts/verify.sh
@@ -24,6 +24,17 @@ effort_configurator=$plugin_dir/scripts/configure-effort.py
 benchmark_scorecard=$plugin_dir/scripts/benchmark-scorecard.py
 effort_wrapper=$repo_root/scripts/configure-effort.sh
 marketplace=$repo_root/.agents/plugins/marketplace.json
+canonical_license=$repo_root/LICENSE
+canonical_notice=$repo_root/NOTICE.md
+plugin_license=$plugin_dir/LICENSE
+plugin_notice=$plugin_dir/NOTICE.md
+
+[ -f "$canonical_license" ] || fail "canonical notice is missing: LICENSE"
+[ -f "$canonical_notice" ] || fail "canonical notice is missing: NOTICE.md"
+[ -f "$plugin_license" ] || fail "required distributable notice is missing: LICENSE"
+[ -f "$plugin_notice" ] || fail "required distributable notice is missing: NOTICE.md"
+cmp -s "$canonical_license" "$plugin_license" || fail "distributable notice differs from repository root: LICENSE"
+cmp -s "$canonical_notice" "$plugin_notice" || fail "distributable notice differs from repository root: NOTICE.md"
 
 for required in "$manifest" "$skill" "$modes" "$templates" "$routing" "$installer" "$inspector" "$launcher" "$effort_settings" "$effort_configurator" "$benchmark_scorecard" "$effort_wrapper"; do
   [ -f "$required" ] || fail "required file is missing: $required"
@@ -45,8 +56,8 @@ manifest_path, skill_path, modes_path, templates_path, routing_path, agent_dir, 
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 if manifest.get("name") != "astral-orchestrator":
     raise SystemExit("manifest name must be astral-orchestrator")
-if manifest.get("version") != "3.1.2":
-    raise SystemExit("manifest version must be Astral Orchestrator v3.1.2")
+if manifest.get("version") != "3.1.3":
+    raise SystemExit("manifest version must be Astral Orchestrator v3.1.3")
 if manifest.get("skills") != "./skills/":
     raise SystemExit("manifest skills path must be ./skills/")
 if manifest.get("license") != "MIT":

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -2,6 +2,7 @@ import importlib.util
 import io
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -15,6 +16,10 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[1]
 MARKETPLACE = ROOT / ".agents/plugins/marketplace.json"
 PLUGIN = ROOT / "plugins/astral-orchestrator"
+LICENSE = ROOT / "LICENSE"
+NOTICE = ROOT / "NOTICE.md"
+PLUGIN_LICENSE = PLUGIN / "LICENSE"
+PLUGIN_NOTICE = PLUGIN / "NOTICE.md"
 MANIFEST = PLUGIN / ".codex-plugin/plugin.json"
 SKILL = PLUGIN / "skills/astral-orchestrator/SKILL.md"
 MODES = PLUGIN / "skills/astral-orchestrator/references/modes-and-risk.md"
@@ -64,7 +69,7 @@ class MarketplaceTests(unittest.TestCase):
         manifest = load_json(MANIFEST)
 
         self.assertEqual(manifest["name"], "astral-orchestrator")
-        self.assertEqual(manifest["version"], "3.1.2")
+        self.assertEqual(manifest["version"], "3.1.3")
         self.assertEqual(manifest["license"], "MIT")
         self.assertEqual(manifest["skills"], "./skills/")
         self.assertEqual(manifest["interface"]["displayName"], "Astral Orchestrator")
@@ -840,12 +845,16 @@ class UserExperienceTests(unittest.TestCase):
         self.assertIn("python 3.11", read(ROOT / "README.md").lower())
 
     def test_original_license_and_attribution_are_preserved(self):
-        license_text = read(ROOT / "LICENSE")
-        notice = read(ROOT / "NOTICE.md")
+        license_text = read(LICENSE)
+        notice = read(NOTICE)
 
         self.assertIn("Copyright (c) 2026 Daniel McAteer", license_text)
         self.assertIn("DannyMac180/sol-advisor", notice)
         self.assertIn("MIT", notice)
+
+    def test_distributable_license_and_notice_match_the_canonical_notices(self):
+        self.assertEqual(PLUGIN_LICENSE.read_bytes(), LICENSE.read_bytes())
+        self.assertEqual(PLUGIN_NOTICE.read_bytes(), NOTICE.read_bytes())
 
 
 class BenchmarkScorecardTests(unittest.TestCase):
@@ -1296,6 +1305,60 @@ class BenchmarkScorecardTests(unittest.TestCase):
 
 
 class VerificationTests(unittest.TestCase):
+    def make_package_fixture(self, directory: str) -> Path:
+        fixture_root = Path(directory) / "repository"
+        fixture_plugin = fixture_root / "plugins/astral-orchestrator"
+        fixture_wrapper = fixture_root / "scripts/configure-effort.sh"
+
+        fixture_plugin.parent.mkdir(parents=True)
+        fixture_wrapper.parent.mkdir(parents=True)
+        shutil.copytree(PLUGIN, fixture_plugin)
+        shutil.copy2(LICENSE, fixture_root / "LICENSE")
+        shutil.copy2(NOTICE, fixture_root / "NOTICE.md")
+        shutil.copy2(CONFIGURE_EFFORT_WRAPPER, fixture_wrapper)
+
+        return fixture_root
+
+    def test_repository_verifier_rejects_missing_distributable_notices(self):
+        for filename in ("LICENSE", "NOTICE.md"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as directory:
+                fixture_root = self.make_package_fixture(directory)
+                fixture_plugin = fixture_root / "plugins/astral-orchestrator"
+                (fixture_plugin / filename).unlink()
+
+                result = subprocess.run(
+                    ["sh", str(fixture_plugin / "scripts/verify.sh")],
+                    cwd=fixture_root,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"required distributable notice is missing: {filename}", result.stderr)
+
+    def test_repository_verifier_rejects_changed_distributable_notices(self):
+        for filename in ("LICENSE", "NOTICE.md"):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as directory:
+                fixture_root = self.make_package_fixture(directory)
+                fixture_plugin = fixture_root / "plugins/astral-orchestrator"
+                copy = fixture_plugin / filename
+                copy.write_bytes(copy.read_bytes() + b"\nchanged by test fixture\n")
+
+                result = subprocess.run(
+                    ["sh", str(fixture_plugin / "scripts/verify.sh")],
+                    cwd=fixture_root,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"distributable notice differs from repository root: {filename}",
+                    result.stderr,
+                )
+
     def test_repository_verifier_passes(self):
         verifier = PLUGIN / "scripts/verify.sh"
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- include the canonical MIT license and Sol Advisor attribution in the distributable plugin
- reject missing or modified packaged notices during verification
- bump the plugin and release documentation to v3.1.3

## Verification
- 48 tests passed
- package verifier passed
- setup dry-run passed
- official skill and plugin validators passed
- tagged ZIP matches all 19 files from v3.1.3 byte-for-byte
- fresh Sol High review: ship