### PR TITLE
Release v3.2.0 install and publication sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 - Added 2026-08-04 instruction-context evidence for core, Quick, Guided, and Measured
   bundles while preserving historical v3.1.4 evidence.
 
+### Changed
+
+- Documented the two-command GitHub marketplace install: `codex plugin marketplace add
+  Demonbane18/astral-orchestrator --ref main`, then `codex plugin add
+  astral-orchestrator@astral-orchestrator`. This route uses bundled exact processes;
+  cloning and `scripts/setup.sh` remain the optional faster native-profile route.
+- Clarified that official ChatGPT/Codex directory publication is a separate surface and
+  may lag until the v3.2.0 directory upload is published.
+
 ## 3.1.4 — 2026-08-03
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -2,35 +2,28 @@
 
 # Astral Orchestrator
 
-Astral Orchestrator v3.2.0 is a published, installable, open-source Codex plugin. It
+Astral Orchestrator v3.2.0 is an installable, open-source Codex plugin. It
 helps Codex turn an everyday request into a checked result: Sol stays responsible for
 the plan and final decisions, Luna handles focused work, Terra handles context-heavy
 implementation, and a fresh Sol reviewer checks the finished change.
 
-It is published in this public repository for installation from a local marketplace.
-Marketplace submission and review are separate, so it is not listed or endorsed by
-Codex Marketplace.
+Install it now from this public GitHub marketplace source. The official ChatGPT/Codex
+directory is a separate publication surface and may lag until the v3.2.0 directory upload
+is published. Astral Orchestrator is an independent open-source project, not affiliated
+with or endorsed by OpenAI.
 
 ## Quick Install
 
-Paste this into Codex to install from the public repository:
-
-~~~text
-Install and set up Astral Orchestrator from https://github.com/Demonbane18/astral-orchestrator. Run sh scripts/setup.sh --dry-run first, then sh scripts/setup.sh. Preserve any conflicting agent profiles and run the package verification.
-~~~
-
-Or, from a terminal, copy and run:
+From a terminal where Codex is available, run these two commands:
 
 ~~~sh
-git clone https://github.com/Demonbane18/astral-orchestrator.git
-cd astral-orchestrator
-sh scripts/setup.sh --dry-run
-sh scripts/setup.sh
+codex plugin marketplace add Demonbane18/astral-orchestrator --ref main
+codex plugin add astral-orchestrator@astral-orchestrator
 ~~~
 
-The dry run only prints the commands. The install registers this checkout as a local Codex
-marketplace, adds the plugin, and installs three companion profiles without overwriting a
-different file.
+This is the complete install. It bundles the exact-process launcher, so Guided, Careful,
+and Measured work can prove the pinned Sol, Luna, and Terra routes without requiring
+global native profiles.
 
 ## What Astral Orchestrator does
 
@@ -50,30 +43,36 @@ or third-party Python package. The only local runtime requirement beyond Codex i
 
 - Codex with access to gpt-5.6-sol, gpt-5.6-luna, and gpt-5.6-terra.
 - Python 3.11 or newer; the included tools use only the Python standard library.
-- A new Codex task after installation, so Codex can discover the plugin and profiles.
+- A new Codex task after installation, so Codex can discover the plugin. It also discovers
+  native profiles when you choose the optional setup below.
 
-Setup installs profiles; it cannot grant access to models your Codex account does not
-have. Astral Orchestrator stops instead of quietly choosing a different model or effort.
+The optional setup installs profiles; it cannot grant access to models your Codex account
+does not have. Astral Orchestrator stops instead of quietly choosing a different model or
+effort.
 
 ## Installation
 
-### Codex-assisted
+### GitHub marketplace install (recommended)
 
-Open this complete repository in Codex and use the Quick Install prompt above. Codex can
-run the dry run, installation, and verification for you. Installation changes your local
-Codex configuration only after you run the non-dry command.
+The two Quick Install commands add this GitHub repository at its `main` ref, then install
+the `astral-orchestrator` plugin. They are enough for the bundled exact-process route.
 
-### Manual installation
+### Optional native-profile setup
 
-Download the public repository as a ZIP or clone it, open a terminal in its root, and run:
+For faster, more ergonomic native named-agent selection, download the public repository
+as a ZIP or clone it, open a terminal in its root, and run:
 
 ~~~sh
+git clone https://github.com/Demonbane18/astral-orchestrator.git
+cd astral-orchestrator
 sh scripts/setup.sh --dry-run
 sh scripts/setup.sh
 ~~~
 
-Do not install only the plugin folder: the repository-local marketplace file and the
-three profiles are part of the setup.
+The dry run prints the planned local changes. Setup registers the checkout, adds the
+plugin, and installs three companion profiles without overwriting a different file. It is
+an optional enhancement, not a prerequisite: missing or customized native profiles make
+the preflight use the bundled exact-process launcher instead.
 
 ## First use
 
@@ -127,9 +126,9 @@ model choice.
 ## Measured instruction-context footprint
 
 Using `tiktoken` 0.13.0 with the `o200k_base` encoding, the published v3.2.0 core
-`SKILL.md` measures **1,974 tokens**; Quick measures **3,634 tokens**; Guided/full
-measures **5,451 tokens**; and Measured measures **7,610 tokens**. Quick therefore
-avoids **1,817 tokens (33.3%)** compared with eager full-bundle loading.
+`SKILL.md` measures **2,036 tokens**; Quick measures **3,696 tokens**; Guided/full
+measures **5,636 tokens**; and Measured measures **7,795 tokens**. Quick therefore
+avoids **1,940 tokens (34.4%)** compared with eager full-bundle loading.
 
 This measures instruction-context loading only. It does not prove every
 multi-agent run uses fewer total tokens than a single Sol run, and it does not measure
@@ -185,12 +184,13 @@ fresh reviewer uses `gpt-5.6-sol`. The configurable effort settings described ab
 supply each lane's effort (Sol High, Luna XHigh, Terra XHigh, reviewer Sol High by
 default), rather than the prompt choosing a new effort at runtime.
 
-For Guided, Careful, and Measured work, Astral Orchestrator first proves the installed profiles
-match exactly and confirms the route. It uses native custom-agent selection only when
-the host exposes the exact role; otherwise the included launcher starts a separate
-Codex process pinned to the required model and configured effort. The launcher emits an
-ASTRAL_ORCHESTRATOR_ROUTE header with allowlisted route facts, never the task packet,
-instructions, secrets, or file contents.
+For Guided, Careful, and Measured work, Astral Orchestrator first checks whether installed
+native profiles byte-match the shipped profiles. A matching profile plus an exact host
+role can use native named-agent selection. Missing or different profiles do not weaken
+the route or demand setup: they force a successful dry-run of the bundled exact-process
+launcher, which starts a separate Codex process pinned to the required model and
+configured effort. The launcher emits an ASTRAL_ORCHESTRATOR_ROUTE header with
+allowlisted route facts, never the task packet, instructions, secrets, or file contents.
 
 A task name is not proof of the route. Missing or mismatched role, model, effort, or
 review isolation blocks the lane and tells you the smallest corrective action.
@@ -237,7 +237,7 @@ set as a reason to investigate before making a product claim.
 
 ## Safety and privacy
 
-- Existing different agent profiles are never overwritten.
+- Existing different optional native profiles are never overwritten.
 - Profile removal deletes only shipped files that still match exactly.
 - Destructive, credential, publishing, production, and irreversible actions require
   an explicit confirmation gate in Careful mode.
@@ -249,7 +249,8 @@ set as a reason to investigate before making a product claim.
 
 ## Updating and the 3.0 migration
 
-To update a downloaded checkout, replace it with the newer complete repository and run:
+To refresh the optional native profiles in a downloaded checkout, replace it with the
+newer complete repository and run:
 
 ~~~sh
 sh scripts/setup.sh --refresh
@@ -290,8 +291,8 @@ These commands do not delete your downloaded repository or project files.
 | Problem | What to do |
 |---|---|
 | The plugin does not appear | Start a new Codex task, then run codex plugin list --marketplace astral-orchestrator. |
-| Setup reports a profile conflict | Astral Orchestrator will not overwrite a customized profile. Compare it with the shipped profile, preserve any needed customization, then rerun setup. |
-| A route cannot be proven | Run sh scripts/setup.sh --refresh, start a new Sol task at the shown effort, and do not request a fallback. |
+| Setup reports a profile conflict | Astral Orchestrator will not overwrite a customized native profile. Keep it and use the bundled exact-process route, or resolve the difference deliberately before rerunning optional setup. |
+| A route cannot be proven | Confirm the bundled launcher dry run can prove the exact role, model, and effort. Reinstall the GitHub marketplace source or run `sh scripts/setup.sh --refresh` only if you want to restore native profiles; never accept another role, model, or effort as a fallback. |
 | An effort value is rejected | Pick a supported value available to your account; max and ultra are not available everywhere. |
 | Setup cannot find Codex or Python | Install or update Codex and use Python 3.11 or newer, then rerun the dry run. |
 
@@ -316,15 +317,15 @@ the product identifier.
 
 ### Can I share this with a team?
 
-Yes. Share the complete repository, then have each person run the Quick Install steps in
+Yes. Share the GitHub link, then have each person run the two Quick Install commands in
 their own Codex environment. They need their own access to the three models.
 
 ## Sharing
 
 The repository is public at https://github.com/Demonbane18/astral-orchestrator. Share
-the link or a complete archive. Ask recipients to use the Codex-assisted installation
-prompt or the manual setup commands; do not share an installed profile directory on its
-own.
+the link or a complete archive. Ask recipients to use the two GitHub marketplace commands;
+use the optional setup only when native profiles are wanted. Do not share an installed
+profile directory on its own.
 
 ## Contributor commands
 

--- a/benchmarks/context-footprint-2026-08-04.json
+++ b/benchmarks/context-footprint-2026-08-04.json
@@ -17,10 +17,10 @@
   "files": [
     {
       "path": "plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md",
-      "bytes": 9378,
-      "words": 1322,
-      "tokens": 1974,
-      "sha256": "ed32a92b15081aea6fee70bed9aa7fcf805d2646d619a92a709e10797b64241a"
+      "bytes": 9711,
+      "words": 1372,
+      "tokens": 2036,
+      "sha256": "dd110e34d4003ef56d3d6cb6f4eefff4cbffc0e6cf0cdc1612772ecd653ad2d1"
     },
     {
       "path": "plugins/astral-orchestrator/skills/astral-orchestrator/references/modes-and-risk.md",
@@ -38,10 +38,10 @@
     },
     {
       "path": "plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md",
-      "bytes": 8616,
-      "words": 1220,
-      "tokens": 1817,
-      "sha256": "19c8250dde0475626b956569217a271bc74ed48fbb0dcbf14dcbaaf7fedc4a2d"
+      "bytes": 9310,
+      "words": 1316,
+      "tokens": 1940,
+      "sha256": "5ad85b9fd5121e8a7665b120c104a7f84ef3d0e62d650c74219b966d0e287d19"
     },
     {
       "path": "plugins/astral-orchestrator/skills/astral-orchestrator/references/measured-mode.md",
@@ -56,7 +56,7 @@
       "paths": [
         "plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md"
       ],
-      "tokens": 1974
+      "tokens": 2036
     },
     "quick": {
       "paths": [
@@ -64,7 +64,7 @@
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/modes-and-risk.md",
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/work-templates.md"
       ],
-      "tokens": 3634
+      "tokens": 3696
     },
     "full": {
       "paths": [
@@ -73,7 +73,7 @@
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/work-templates.md",
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md"
       ],
-      "tokens": 5451
+      "tokens": 5636
     },
     "guided": {
       "paths": [
@@ -82,7 +82,7 @@
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/work-templates.md",
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md"
       ],
-      "tokens": 5451
+      "tokens": 5636
     },
     "measured": {
       "paths": [
@@ -92,12 +92,12 @@
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md",
         "plugins/astral-orchestrator/skills/astral-orchestrator/references/measured-mode.md"
       ],
-      "tokens": 7610
+      "tokens": 7795
     }
   },
   "quick_vs_full": {
-    "tokens_avoided": 1817,
-    "percent_avoided": 33.3
+    "tokens_avoided": 1940,
+    "percent_avoided": 34.4
   },
   "scope_note": "This measures instruction-context loading only. It does not measure outcome quality, latency, price, or total tokens for a complete run."
 }

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -7,8 +7,9 @@ one Sol orchestrator, two pinned implementation lanes, exact route evidence, bou
 ownership, independent verification, and a fresh pinned Sol reviewer.
 
 The design focuses on usability without weakening the route contract. It keeps Quick,
-Guided, and Careful language, uses namespaced profiles, gives non-technical users one
-setup command, and refuses to silently downgrade a requested model or effort.
+Guided, Careful, and Measured language, gives non-technical users a two-command GitHub
+install with optional namespaced native profiles, and refuses to silently downgrade a
+requested model or effort.
 
 ## Route comparison
 
@@ -20,15 +21,16 @@ setup command, and refuses to silently downgrade a requested model or effort.
 | Reviewer | Fresh Sol High, requested read-only | Fresh Sol at configured effort; High by default and requested read-only |
 | Routing proof | Native metadata plus allowlisted rollout inspection | Same guarantee with a Python standard-library inspector |
 | User controls | Architecture-oriented workflow | Quick, Guided, Careful, and explicit Measured modes |
-| Installation | Companion agent installer | Plugin setup plus conflict-safe profile installer |
+| Installation | Companion agent installer | Two-command GitHub plugin install plus optional conflict-safe native-profile setup |
 | Removal | Manual profile cleanup | --remove deletes only exact, unmodified profiles |
 | Failure | Stop when strict preflight fails | Same; never silently substitute another lane |
 | Effort tuning | Profile-oriented | One command and persistent per-lane settings |
 
 ## Improvements beyond the original
 
-1. **One beginner setup path.** sh scripts/setup.sh registers the marketplace, installs
-   all three profiles, and installs the plugin.
+1. **Two simple install choices.** Two GitHub marketplace commands install the plugin
+   with its bundled exact-process route. `sh scripts/setup.sh` remains an optional,
+   conflict-safe native-profile install for faster named-agent selection.
 2. **Safer lifecycle.** Existing different profiles are never overwritten, and modified
    profiles are never removed automatically.
 3. **No extra JSON package.** The runtime inspector uses Python 3's standard library

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -7,10 +7,11 @@ orchestration. A Sol task leads, assigns bounded work to Luna or Terra based on 
 integrates and verifies the result, then uses a fresh Sol reviewer. Each lane's reasoning
 effort is configurable without editing profiles.
 
-The user should not need to understand TOML files, runtime logs, or agent APIs. One setup
-command installs the plugin and three namespaced profiles. When an exact route cannot be
-proven, the workflow stops rather than claiming a generic fallback was the requested
-orchestration.
+The user should not need to understand TOML files, runtime logs, or agent APIs. Two
+GitHub marketplace commands install the plugin and its bundled exact-process launcher.
+The optional setup command installs three namespaced native profiles for faster,
+more-ergonomic named-agent selection. When an exact route cannot be proven, the workflow
+stops rather than claiming a generic fallback was the requested orchestration.
 
 Version 3.1 adds a local JSONL benchmark scorecard. It compares paired, repeated Astral
 and single-Sol trials only after validating frozen task fingerprints, identical
@@ -39,10 +40,11 @@ modified automatically.
 2. The primary task starts with gpt-5.6-sol at the configured reasoning effort; High is
    the default.
 3. Recipients have access to gpt-5.6-luna, gpt-5.6-terra, and gpt-5.6-sol.
-4. Custom agents are installed to Codex's personal agents directory and are discovered
-   in a newly started task.
-5. When a host lacks native custom-agent selection, the bundled launcher may start an
-   exact pinned Codex process for the same lane.
+4. Optional native custom agents, when installed, live in Codex's personal agents
+   directory and are discovered in a newly started task.
+5. When native profiles are missing or customized, or a host lacks exact native
+   custom-agent selection, the bundled launcher starts an exact pinned Codex process for
+   the same lane.
 6. The project homepage is https://github.com/Demonbane18/astral-orchestrator.
 7. The MIT-licensed Sol Advisor source may be adapted with preserved notice.
 
@@ -107,7 +109,8 @@ probe with the identical card; material disagreement defaults to Terra.
 
 ## Success criteria
 
-1. One setup command installs one plugin and exactly three namespaced profiles.
+1. Two GitHub marketplace commands install the plugin; optional setup installs exactly
+   three namespaced native profiles.
 2. Profiles pin Sol High, Luna XHigh, and Terra XHigh exactly as specified.
 3. The skill routes by work characteristics and parallelizes only non-overlapping cards.
 4. Runtime inspection emits only allowlisted route fields.

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md
@@ -56,12 +56,16 @@ ask the user once to confirm the model and effort; record that as **user-confirm
 observed evidence. A changed orchestrator setting applies to a new task, not the task
 already running.
 
-For Guided, Careful, and Measured work, also run the bundled profile installer's exact `--check`.
-Use a named native custom role only when its pinned profile effort equals the configured
-effort. A custom worker or reviewer effort must use the exact-process launcher, which
-starts the pinned model with that configured effort and the shipped role instructions.
-If profiles differ or neither route can run, tell the user to rerun setup. A blocking
-preflight ends the current turn. Never silently lower an unsupported effort.
+For Guided, Careful, and Measured work, select one of two exact routes. First run the
+bundled profile installer's exact `--check`. A pass permits native selection only when
+the host exposes the exact role and its native profile effort equals the configured
+effort. When that check reports missing or different native profiles, or the host cannot
+make that exact native selection, run a successful dry-run of the bundled exact-process
+launcher for the needed role. That route starts the pinned model with the configured
+effort and shipped role instructions. Missing or different native profiles force the
+exact-process route; they do not permit substitution or make optional setup required.
+Stop only when neither exact route can be proven. A blocking preflight ends the current
+turn. Never silently lower an unsupported effort.
 
 When the user explicitly asks to show or change effort settings, run the configuration
 script. Preserve unspecified lanes and report the resulting four values. Use `--reset`
@@ -70,9 +74,10 @@ model- and account-dependent.
 
 Do not silently substitute a built-in or differently configured agent. Give every lane
 a complete standalone work packet. For a native lane, use `fork_turns: "none"`. For an
-exact-process lane, use the bundled launcher with the matching role. Combine the
-byte-exact profile check, requested route, task or session id, and observed model/effort
-evidence before accepting its work. The routing guide defines the exact behavior.
+exact-process lane, use the bundled launcher with the matching role. Combine the native
+profile status or successful launcher dry-run, requested route, task or session id, and
+observed model/effort evidence before accepting its work. The routing guide defines the
+exact behavior.
 
 ## 3. Frame and decompose the work
 

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
@@ -38,15 +38,19 @@ Before execution in any mode:
 Before Guided, Careful, or Measured execution, additionally:
 
 5. Resolve `../../scripts/install-agents.sh` relative to this skill and run it with
-   `--check` so the installed profiles byte-match the shipped profiles.
-6. Confirm either the collaboration tool exposes an exact custom `agent_type` selector,
-   or the bundled `../../scripts/run-agent.py` passes a dry-run for the needed role.
+   `--check`. A pass records `native profiles: exact`; a missing or different profile
+   records `native profiles: unavailable` and is not a preflight failure.
+6. Use native selection only when step 5 passed, the collaboration tool exposes the
+   exact custom `agent_type`, and the native profile effort equals the configured value.
+   Otherwise, resolve `../../scripts/run-agent.py` and require a successful dry-run for
+   the needed role, workdir, and private packet.
 
-If the primary route is neither observable nor explicitly user-confirmed, or if step 5
-or 6 fails, stop before implementation. Explain the missing item and the smallest
-corrective action: run `sh scripts/setup.sh --refresh` from the Astral Orchestrator repository
-when profiles are missing or different, then start a new task with Sol and the configured
-orchestrator effort. Do not fall back to another route.
+If the primary route is neither observable nor explicitly user-confirmed, or if both the
+native route and bundled launcher dry-run fail, stop before implementation. Explain the
+missing item and the smallest corrective action. Missing or different native profiles
+force the exact-process route; they do not permit substitution and do not require setup.
+Optional setup can restore native named-agent ergonomics, but it is never evidence for a
+different model or effort. Do not fall back to another route.
 
 Quick mode intentionally uses only the verified Sol primary session at the configured
 orchestrator effort and does not need custom worker availability.
@@ -81,11 +85,13 @@ its stricter deterministic selection rules rather than a general heuristic.
 
 ## Choose the execution mechanism
 
-Prefer a native custom agent only when the collaboration tool exposes an explicit
-`agent_type` field, the exact Astral Orchestrator role, and its native profile effort matches
-the configured value. Do not treat a task name as an agent type; current hosts can
-otherwise create a default Sol agent under a Luna-looking name. A custom effort that
-differs from the native profile always uses the exact-process mechanism.
+Prefer a native custom agent only when the installed native profile check passed, the
+collaboration tool exposes an explicit `agent_type` field, the exact Astral Orchestrator
+role, and its native profile effort matches the configured value. Do not treat a task name
+as an agent type; current hosts can otherwise create a default Sol agent under a
+Luna-looking name. A custom effort that differs from the native profile always uses the
+exact-process mechanism. Missing or different native profiles force the exact-process
+route; they do not permit substitution.
 
 When native selection is unavailable, use the **exact-process** mechanism. Resolve
 `../../scripts/run-agent.py` relative to this skill, write the complete standalone work
@@ -99,8 +105,9 @@ The launcher reads the shipped profile, reads the effective effort settings, pin
 model and configured effort on `codex exec`, injects the profile's developer
 instructions that forbid further delegation, and selects workspace-write for workers
 or read-only for the reviewer. Its evidence marks whether the effort is the default and
-whether the native profile is compatible. Remove only the exact temporary packet after
-the process exits. A non-zero exit blocks the lane.
+whether a native profile would be compatible. A successful dry-run proves this bundled
+exact-process contract without requiring installed native profiles. Remove only the
+exact temporary packet after the process exits. A non-zero exit blocks the lane.
 
 ## Spawn and runtime evidence
 
@@ -156,6 +163,7 @@ The orchestrator inspects every returned change before another lane builds on it
 
 The reviewer profile requests a read-only sandbox, and the exact-process launcher passes
 that mode explicitly. The host still controls the effective sandbox. Record the observed
-sandbox and never overstate isolation. In Careful mode, observed non-read-only access
-makes review incomplete. After any fix, create a new native reviewer with
+sandbox and never overstate isolation. In Careful mode, require the exact pinned Sol
+reviewer and observed read-only access; requested read-only access alone is insufficient.
+Observed non-read-only access makes review incomplete. After any fix, create a new native reviewer with
 `fork_turns: "none"` or a new reviewer process; never reuse the previous review context.

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -206,6 +206,8 @@ class SkillContractTests(unittest.TestCase):
         self.assertIn("--check", routing)
         self.assertIn("run-agent.py", routing)
         self.assertIn("exact-process", routing)
+        self.assertIn("exact pinned sol", routing)
+        self.assertIn("observed read-only access", routing)
 
     def test_companion_agent_profiles_pin_exact_models_and_effort(self):
         expected = {
@@ -936,9 +938,15 @@ class UserExperienceTests(unittest.TestCase):
     def test_readme_explains_heuristic_routing_and_the_local_benchmark(self):
         readme = " ".join(read(ROOT / "README.md").lower().split())
 
-        self.assertIn("published, installable, open-source codex plugin", readme)
+        self.assertIn("installable, open-source codex plugin", readme)
         self.assertIn("v3.2.0", readme)
-        self.assertIn("not listed or endorsed by codex marketplace", readme)
+        self.assertIn(
+            "codex plugin marketplace add demonbane18/astral-orchestrator --ref main",
+            readme,
+        )
+        self.assertIn("codex plugin add astral-orchestrator@astral-orchestrator", readme)
+        self.assertIn("official chatgpt/codex directory", readme)
+        self.assertIn("separate publication surface", readme)
         self.assertIn("mode determines whether to delegate", readme)
         self.assertIn("work characteristics choose sol, luna, or terra", readme)
         self.assertIn("instruction-context loading only", readme)
@@ -965,6 +973,57 @@ class UserExperienceTests(unittest.TestCase):
             self.assertEqual(excalidraw["type"], "excalidraw")
             self.assertTrue(excalidraw["elements"])
 
+    def test_preflight_uses_the_bundled_launcher_when_native_profiles_are_absent(self):
+        skill = read(SKILL).lower()
+        routing = read(ROUTING).lower()
+
+        self.assertIn("successful dry-run", skill)
+        self.assertIn("missing or different native profiles", routing)
+        self.assertIn("force the exact-process route", routing)
+        self.assertIn("do not permit substitution", routing)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            native_profiles = root / "agents"
+            native_check = subprocess.run(
+                ["sh", str(INSTALL_AGENTS), "--target-dir", str(native_profiles), "--check"],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(native_check.returncode, 0)
+
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            prompt.write_text("bounded standalone packet\n", encoding="utf-8")
+            prompt.chmod(0o600)
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(RUN_AGENT),
+                    "--role",
+                    "terra",
+                    "--workdir",
+                    str(workdir),
+                    "--prompt-file",
+                    str(prompt),
+                    "--settings-file",
+                    str(root / "no-settings.toml"),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            evidence = json.loads(result.stdout)
+            self.assertEqual(evidence["agent_name"], "astral_orchestrator_terra_implementer")
+            self.assertEqual(evidence["model"], "gpt-5.6-terra")
+            self.assertEqual(evidence["effort"], "xhigh")
+
     def test_readme_publishes_banner_footprint_and_ori_eval_attribution(self):
         readme = read(ROOT / "README.md")
         first_lines = readme.lstrip().splitlines()
@@ -981,16 +1040,16 @@ class UserExperienceTests(unittest.TestCase):
             self.assertIn(visible_element, first_lines[0])
         self.assertIn("# Astral Orchestrator", first_lines[:4])
 
-        for figure in ("1,974", "3,634", "5,451", "7,610", "1,817", "33.3%"):
+        for figure in ("2,036", "3,696", "5,636", "7,795", "1,940", "34.4%"):
             self.assertIn(figure, readme)
         footprint = " ".join(
             readme.split("## Measured instruction-context footprint", 1)[1]
             .split("## Configurable effort levels", 1)[0]
             .split()
         )
-        self.assertIn("published v3.2.0 core `SKILL.md` measures **1,974 tokens**", footprint)
-        self.assertIn("Guided/full measures **5,451 tokens**", footprint)
-        self.assertIn("Measured measures **7,610 tokens**", footprint)
+        self.assertIn("published v3.2.0 core `SKILL.md` measures **2,036 tokens**", footprint)
+        self.assertIn("Guided/full measures **5,636 tokens**", footprint)
+        self.assertIn("Measured measures **7,795 tokens**", footprint)
         self.assertIn("instruction-context loading only", footprint)
         self.assertIn("quality, latency, or price", footprint)
         self.assertIn("total tokens for a complete run", footprint)

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -303,8 +303,10 @@ class WebsiteContractTests(unittest.TestCase):
     def test_install_page_has_copyable_install_command(self):
         install = page_text(PAGES["install"])
         for phrase in (
-            "git clone https://github.com/Demonbane18/astral-orchestrator.git",
-            "sh scripts/setup.sh --dry-run",
+            "codex plugin marketplace add Demonbane18/astral-orchestrator --ref main",
+            "codex plugin add astral-orchestrator@astral-orchestrator",
+            "bundled exact-process launcher",
+            "Optional native-profile setup",
             "https://github.com/Demonbane18/astral-orchestrator",
         ):
             self.assertIn(phrase, install)
@@ -804,18 +806,18 @@ class WebsiteContractTests(unittest.TestCase):
             page_text(ROOT / "benchmarks" / "context-footprint-2026-08-04.json")
         )
         expected_bundles = {
-            "core": 1974,
-            "quick": 3634,
-            "guided": 5451,
-            "measured": 7610,
+            "core": 2036,
+            "quick": 3696,
+            "guided": 5636,
+            "measured": 7795,
         }
         self.assertEqual(
             {name: benchmark["bundles"][name]["tokens"] for name in expected_bundles},
             expected_bundles,
         )
-        self.assertEqual(benchmark["quick_vs_full"]["tokens_avoided"], 1817)
-        self.assertEqual(benchmark["quick_vs_full"]["percent_avoided"], 33.3)
-        for figure in ("1,974", "3,634", "5,451", "7,610", "1,817", "33.3%"):
+        self.assertEqual(benchmark["quick_vs_full"]["tokens_avoided"], 1940)
+        self.assertEqual(benchmark["quick_vs_full"]["percent_avoided"], 34.4)
+        for figure in ("2,036", "3,696", "5,636", "7,795", "1,940", "34.4%"):
             with self.subTest(figure=figure):
                 self.assertIn(figure, home)
         for scope_statement in (

--- a/website/index.html
+++ b/website/index.html
@@ -382,26 +382,26 @@
             <div class="chart-card" data-reveal>
               <h3>Instruction-context tokens, by loading path</h3>
               <p class="chart-sub">Static instruction-context measurements · tiktoken 0.13.0 · o200k_base · v3.2.0 · 2026-08-04</p>
-              <div class="chart" data-chart role="img" aria-label="Bar chart of static instruction-context tokens. Measured costs 7,610 tokens. Guided and full cost 5,451 tokens. Quick costs 3,634 tokens. The core skill costs 1,974 tokens.">
+              <div class="chart" data-chart role="img" aria-label="Bar chart of static instruction-context tokens. Measured costs 7,795 tokens. Guided and full cost 5,636 tokens. Quick costs 3,696 tokens. The core skill costs 2,036 tokens.">
                 <div class="chart-row">
                   <span class="chart-label">Measured <small>explicit evidence route</small></span>
                   <span class="chart-track"><span class="chart-bar chart-bar--measured"></span></span>
-                  <span class="chart-value" data-count-to="7610">7,610</span>
+                  <span class="chart-value" data-count-to="7795">7,795</span>
                 </div>
                 <div class="chart-row">
                   <span class="chart-label">Guided / full <small>normal project route</small></span>
                   <span class="chart-track"><span class="chart-bar chart-bar--full"></span></span>
-                  <span class="chart-value" data-count-to="5451">5,451</span>
+                  <span class="chart-value" data-count-to="5636">5,636</span>
                 </div>
                 <div class="chart-row">
                   <span class="chart-label">Quick path <small>tiny tasks</small></span>
                   <span class="chart-track"><span class="chart-bar chart-bar--quick"></span></span>
-                  <span class="chart-value" data-count-to="3634">3,634</span>
+                  <span class="chart-value" data-count-to="3696">3,696</span>
                 </div>
                 <div class="chart-row">
                   <span class="chart-label">Core skill <small>always loaded</small></span>
                   <span class="chart-track"><span class="chart-bar chart-bar--core"></span></span>
-                  <span class="chart-value" data-count-to="1974">1,974</span>
+                  <span class="chart-value" data-count-to="2036">2,036</span>
                 </div>
               </div>
               <p class="chart-footnote">Scope: static instruction-context measurements only, not task quality, latency, price, or total-run tokens. Regenerate the published v3.2.0 measurement with one command from <code>benchmarks/</code> in the repository.</p>
@@ -409,15 +409,15 @@
 
             <div class="stat-stack">
               <div class="stat-card" data-reveal>
-                <span class="stat-number"><span data-stat-count data-count-to="33.3" data-decimals="1">33.3</span><span class="stat-unit">%</span></span>
+                <span class="stat-number"><span data-stat-count data-count-to="34.4" data-decimals="1">34.4</span><span class="stat-unit">%</span></span>
                 <span class="stat-label">instruction-context tokens Quick avoids versus Guided / full loading</span>
               </div>
               <div class="stat-card" data-reveal>
-                <span class="stat-number"><span data-stat-count data-count-to="1817">1,817</span></span>
+                <span class="stat-number"><span data-stat-count data-count-to="1940">1,940</span></span>
                 <span class="stat-label">instruction-context tokens Quick avoids versus Guided / full loading</span>
               </div>
               <div class="stat-card" data-reveal>
-                <span class="stat-number"><span data-stat-count data-count-to="1974">1,974</span></span>
+                <span class="stat-number"><span data-stat-count data-count-to="2036">2,036</span></span>
                 <span class="stat-label">tokens for the entire core skill in the published v3.2.0 measurement</span>
               </div>
             </div>
@@ -428,7 +428,7 @@
               <h3><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 4.5 13.5H11L9.5 22 19 10h-6.5L13 2Z"></path></svg>Token-efficient by design</h3>
               <p>
                 Progressive disclosure is measured, not hoped for: the Quick route
-                avoids <span class="hl">1,817 instruction-context tokens (33.3%)</span>
+                avoids <span class="hl">1,940 instruction-context tokens (34.4%)</span>
                 compared with Guided / full loading. And because Luna and Terra receive
                 bounded task packets, workers never re-read the whole conversation
                 either.
@@ -468,7 +468,7 @@
             <div>
               <p class="eyebrow">Ready when you are</p>
               <h2 id="cta-title">Two minutes to a steadier route.</h2>
-              <p>One clone, one dry run, one install. The plugin works in your local Codex and project environment.</p>
+              <p>Two terminal commands add the GitHub marketplace and install the plugin in your local Codex and project environment. The optional native-profile setup remains available when you want it.</p>
             </div>
             <a class="button button-primary" href="install/">Open the quick install</a>
           </div>

--- a/website/install/index.html
+++ b/website/install/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Quick install for Astral Orchestrator: clone the repository, preview with a dry run, then install the local Codex plugin.">
+    <meta name="description" content="Quick install for Astral Orchestrator from its GitHub marketplace source in two commands.">
     <meta name="theme-color" content="#f4f2ec">
     <title>Quick Install · Astral Orchestrator</title>
     <link rel="icon" type="image/png" href="../assets/astral-orchestrator-favicon-32.png">
@@ -57,8 +57,8 @@
       <header class="page-header">
         <div class="shell">
           <p class="eyebrow">Quick install</p>
-          <h1>From clone to checked work in four commands.</h1>
-          <p class="page-lede">Astral Orchestrator v3.2.0 adds an explicit opt-in Measured mode alongside the familiar routes. The dry run only prints what it would change, so you can look before you leap. The real install registers the local marketplace, adds the plugin, and installs three companion profiles, and it never overwrites a profile that is different from the shipped one.</p>
+          <h1>Install from GitHub in two commands.</h1>
+          <p class="page-lede">Astral Orchestrator v3.2.0 installs directly from its GitHub marketplace source. This route includes the bundled exact-process launcher, which preserves the pinned Sol, Luna, and Terra model-and-effort contract without requiring native profiles.</p>
         </div>
       </header>
 
@@ -70,26 +70,24 @@
               <div class="terminal">
                 <div class="terminal-bar" aria-hidden="true"><i></i><i></i><i></i><span>terminal</span></div>
                 <div class="command-wrap">
-                  <pre id="install-command"><code><span>git clone https://github.com/Demonbane18/astral-orchestrator.git</span>
-<span>cd astral-orchestrator</span>
-<span>sh scripts/setup.sh --dry-run</span>
-<span>sh scripts/setup.sh</span></code></pre>
+                  <pre id="install-command"><code><span>codex plugin marketplace add Demonbane18/astral-orchestrator --ref main</span>
+<span>codex plugin add astral-orchestrator@astral-orchestrator</span></code></pre>
                   <button class="copy-button" type="button" data-copy-target="#install-command" data-copy-status="install-command-copy-status" aria-label="Copy the installation command" aria-describedby="install-command-copy-status">Copy command</button>
                 </div>
               </div>
               <p class="copy-status" id="install-command-copy-status" role="status" aria-live="polite" aria-atomic="true"></p>
               <ul class="check-list">
-                <li><strong>Clone</strong> the complete repository, not just the plugin folder.</li>
-                <li><strong>Dry run</strong> prints the planned commands and changes nothing.</li>
-                <li><strong>Install</strong> adds the marketplace, plugin, and profiles.</li>
-                <li><strong>Start a new Codex task</strong> afterwards, so Codex discovers everything.</li>
+                <li><strong>Add</strong> the GitHub marketplace source at its <code>main</code> ref.</li>
+                <li><strong>Install</strong> the <code>astral-orchestrator</code> plugin.</li>
+                <li><strong>Use</strong> the bundled exact-process launcher when native profiles are absent or customized.</li>
+                <li><strong>Start a new Codex task</strong> afterwards, so Codex discovers the plugin.</li>
               </ul>
             </div>
 
             <div class="install-card" data-reveal>
-              <h2>Prefer Codex to run it for you?</h2>
-              <p>Open the cloned repository in Codex and paste this prompt:</p>
-              <p class="prompt-box" id="codex-prompt">Install and set up Astral Orchestrator from https://github.com/Demonbane18/astral-orchestrator. Run sh scripts/setup.sh --dry-run first, then sh scripts/setup.sh. Preserve any conflicting agent profiles and run the package verification.</p>
+              <h2>Want native named profiles too?</h2>
+              <p>Optional native-profile setup is faster and more ergonomic, but is not required for exact routing. Clone the repository and paste this into Codex or a terminal:</p>
+              <p class="prompt-box" id="codex-prompt">git clone https://github.com/Demonbane18/astral-orchestrator.git &amp;&amp; cd astral-orchestrator &amp;&amp; sh scripts/setup.sh --dry-run &amp;&amp; sh scripts/setup.sh</p>
               <p>
                 <button class="copy-button" type="button" data-copy-target="#codex-prompt" data-copy-status="codex-prompt-copy-status" aria-label="Copy the Codex install prompt" aria-describedby="codex-prompt-copy-status">Copy prompt</button>
               </p>

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -65,11 +65,11 @@
       <section class="section">
         <div class="shell content-grid">
           <div class="prose">
-            <h2>Read the setup guidance first</h2>
+            <h2>Read the install guidance first</h2>
             <p>
               The <a href="https://github.com/Demonbane18/astral-orchestrator#readme">repository README</a>
-              is the source for the complete install flow, requirements, modes, and troubleshooting.
-              In particular, try the dry-run command before an install so you can inspect the planned local changes.
+              is the source for the two-command GitHub install, requirements, modes, and troubleshooting.
+              The dry-run setup is optional guidance for people who also want native named profiles.
             </p>
 
             <h2>Open a useful issue</h2>


### PR DESCRIPTION
## Summary
- lead with the two-command GitHub marketplace install
- make native profiles optional while preserving exact Sol/Luna/Terra process routing
- synchronize README, website, support copy, benchmark evidence, tests, and release wording

## Verification
- 78 unit/contract tests passed
- package verifier passed
- official skill and plugin validators passed
- pinned tiktoken 0.13 evidence matched
- Opera GX visual QA passed
- fresh exact Sol High read-only reviewer: ship