### PR TITLE
Astral Orchestrator v3.3.0: Morph and Constellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.3.0 — 2026-08-09
+
+### Added
+
+- Added automatic local primary-route verification for Codex before fixed-mode delegation.
+- Added explicit opt-in Morph and capacity-aware Constellation worker routes while preserving
+  all six modes: Quick, Guided, Careful, Measured, Morph, and Constellation.
+- Added an additive portable package manifest and capability boundary for non-Codex hosts;
+  skill discovery does not claim portable orchestration, model routing, or concurrency.
+
+### Changed
+
+- Clarified that cross-host Morph and Constellation require observed model, worker-context,
+  concurrency where applicable, and fresh-reviewer capabilities before use.
+
 ## 3.2.0 — 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Astral Orchestrator
 
-Astral Orchestrator v3.2.0 is an installable, open-source Codex plugin. It
+Astral Orchestrator v3.3.0 is an installable, open-source Codex plugin. It
 helps Codex turn an everyday request into a checked result: Sol stays responsible for
 the plan and final decisions, Luna handles focused work, Terra handles context-heavy
 implementation, and a fresh Sol reviewer checks the finished change.
 
 Install it now from this public GitHub marketplace source. The official ChatGPT/Codex
-directory is a separate publication surface and may lag until the v3.2.0 directory upload
+directory is a separate publication surface and may lag until the v3.3.0 directory upload
 is published. Astral Orchestrator is an independent open-source project, not affiliated
 with or endorsed by OpenAI.
 
@@ -21,9 +21,10 @@ codex plugin marketplace add Demonbane18/astral-orchestrator --ref main
 codex plugin add astral-orchestrator@astral-orchestrator
 ~~~
 
-This is the complete install. It bundles the exact-process launcher, so Guided, Careful,
+This is the complete install. It bundles the fixed-route launcher, so Guided, Careful,
 and Measured work can prove the pinned Sol, Luna, and Terra routes without requiring
-global native profiles.
+global native profiles. Morph and Constellation are separate explicit opt-ins; they do not
+change the verified Sol primary or fresh Sol reviewer.
 
 ## What Astral Orchestrator does
 
@@ -33,6 +34,10 @@ Astral Orchestrator gives you a repeatable way to:
 2. send narrow, repeatable work to Luna and context-heavy implementation to Terra;
 3. inspect the actual changes and run relevant checks;
 4. request a fresh Sol review before handoff.
+
+Before fixed-mode delegation, the bundled primary checker automatically verifies the
+current Codex primary route when local runtime evidence is available. A mismatch blocks
+the route; unavailable evidence is clearly labeled rather than guessed.
 
 It works for code, documents, configuration, research artifacts, and other
 workspace-based projects. It adds no API key, paid service, background server, analytics,
@@ -87,6 +92,13 @@ You can also ask it to fix an error or complete a documentation change. Guided m
 the default, so you only need to name a mode when you want a different level of process.
 
 For an evidence-oriented run, say “Use Astral Orchestrator in Measured mode.”
+For a bounded card with a user-selected model route, say “Use Astral Orchestrator in Morph
+mode.” For independent cards that may safely fan out, say “Use Astral Orchestrator in
+Constellation mode.”
+
+Morph’s optional OpenCodex provider route is user-owned: configure it separately if you
+choose it. Astral Orchestrator does not install providers, handle credentials, or claim
+that a requested effort was accepted natively by an external model.
 
 ## Modes
 
@@ -96,10 +108,14 @@ For an evidence-oriented run, say “Use Astral Orchestrator in Measured mode.�
 | Guided | Normal changes and projects | Sol plans, Luna or Terra implements bounded work, and fresh Sol reviews it. |
 | Careful | Credentials, payments, private data, production, migrations, or major changes | Visible plan, confirmation gates, pinned workers, strict verification, and read-only reviewer evidence. |
 | Measured (explicit opt-in) | A deliberately evidence-oriented request | Sol freezes one canonical card, records private local evidence, routes one pinned worker, and requests fresh Sol review. |
+| Morph (explicit opt-in) | A bounded worker card that needs a user-selected routed or native model | Sol remains the configured primary, the worker receives an exact model id and requested effort, and fresh Sol reviews the result. |
+| Constellation (explicit opt-in) | Several independent, ready cards | Sol proves independent ownership and host capacity, starts a cost-aware non-Sol first wave, integrates it, and requests one fresh Sol review. |
 
 Astral Orchestrator raises safeguards when a request is riskier than the selected mode.
 It does not broaden the work you asked for.
-Measured is never automatic; Guided remains recommended for normal work.
+Measured, Morph, and Constellation are never automatic; Guided remains recommended for
+normal work. Careful safeguards override either opt-in worker mode whenever the risk
+requires confirmation, serial routing, or observed read-only review isolation.
 
 ## How Astral chooses models and effort
 
@@ -107,7 +123,7 @@ Three separate decisions keep the workflow predictable:
 
 1. **Mode determines whether to delegate.** Quick keeps a tiny change in the Sol primary;
    Guided, Careful, and Measured delegate bounded implementation when there is work that can safely
-   be handed off.
+   be handed off. Morph and Constellation work only when the user explicitly names them.
 2. **Work characteristics choose Sol, Luna, or Terra.** Sol retains requirements,
    architecture, safety boundaries, and acceptance decisions. Luna receives narrow,
    repeatable, fully specified work. Terra receives context-heavy implementation,
@@ -117,6 +133,9 @@ Three separate decisions keep the workflow predictable:
    Terra, and reviewer values before it runs, then either uses the matching profile or
    starts the exact pinned process. It stops if it cannot prove the requested model and
    effort; it does not substitute another route.
+4. **Morph labels a worker request, not provider capability.** The selected model gets the
+   requested effort label, but the route records upstream-native effort as unverified until
+   independent provider evidence exists.
 
 The route below is a documented **heuristic**, based on the type of work and the route
 contract. The separate local outcome scorecard described below is how to collect
@@ -125,7 +144,7 @@ model choice.
 
 ## Measured instruction-context footprint
 
-Using `tiktoken` 0.13.0 with the `o200k_base` encoding, the published v3.2.0 core
+Using `tiktoken` 0.13.0 with the `o200k_base` encoding, the historical v3.2.0 core
 `SKILL.md` measures **2,036 tokens**; Quick measures **3,696 tokens**; Guided/full
 measures **5,636 tokens**; and Measured measures **7,795 tokens**. Quick therefore
 avoids **1,940 tokens (34.4%)** compared with eager full-bundle loading.
@@ -145,7 +164,7 @@ rather than proof of outcome superiority. See the
 
 ## Public evidence status
 
-The current repository verification passed **109 automated tests** and **package verification**.
+The current repository verification passed **100+ automated tests** and **package verification**.
 This validates behavior and contracts; it does not prove Astral beats single-Sol or
 establish a valid outcome comparison.
 
@@ -203,6 +222,12 @@ fresh reviewer uses `gpt-5.6-sol`. The configurable effort settings described ab
 supply each lane's effort (Sol High, Luna XHigh, Terra XHigh, reviewer Sol High by
 default), rather than the prompt choosing a new effort at runtime.
 
+For every mode, Astral first runs its local primary checker. When `CODEX_THREAD_ID` and
+local rollout evidence are available, it automatically verifies that the primary is
+`gpt-5.6-sol` at the configured orchestrator effort. The checker emits only allowlisted
+route fields and never prints prompt or session contents. Only when that evidence is
+unavailable does Astral ask once for the user's confirmation; a mismatch blocks the route.
+
 For Guided, Careful, and Measured work, Astral Orchestrator first checks whether installed
 native profiles byte-match the shipped profiles. A matching profile plus an exact host
 role can use native named-agent selection. Missing or different profiles do not weaken
@@ -213,6 +238,25 @@ allowlisted route facts, never the task packet, instructions, secrets, or file c
 
 A task name is not proof of the route. Missing or mismatched role, model, effort, or
 review isolation blocks the lane and tells you the smallest corrective action.
+
+### Morph and Constellation
+
+Morph is optional. It can use an OpenCodex-routed `provider/model` or another user-selected
+native model only for a bounded worker card. OpenCodex is independently installed and
+configured by the user: Astral never changes `~/.opencodex`, starts a service, installs a
+package, handles credentials, or assumes provider terms-of-service compatibility. It adds
+no network client; its launcher only invokes the existing `codex` command. Provider/model
+support and effort semantics are capability-dependent, and a worker failure blocks that
+worker rather than falling back silently. A configured external or non-OpenAI provider may
+receive the worker packet during model inference. “No network client” means Astral adds no
+network client, service, or credential handling; it does not mean provider traffic is local.
+
+Constellation is also optional. It starts a concurrent first wave only after Sol proves
+that cards are independent and have non-overlapping ownership, the host advertises enough
+available slots after the primary consumes one, and the configured roster has suitable
+cost-aware non-Sol workers. It never hard-codes a child count or creates extra Sol
+implementers by default. If capacity or independence is uncertain, it uses serial
+Guided-style routing instead.
 
 Measured freezes exactly one canonical card and its checks before routing. If Luna versus
 Terra is ambiguous, Sol sends exactly one behaviorally read-only probe to each lane with
@@ -260,11 +304,14 @@ set as a reason to investigate before making a product claim.
 - Profile removal deletes only shipped files that still match exactly.
 - Destructive, credential, publishing, production, and irreversible actions require
   an explicit confirmation gate in Careful mode.
-- Work packets remain local. The exact-process route writes a private temporary packet,
-  passes it only to the selected Codex process, then removes it after that process exits.
-  There is no analytics collection, extra network client, API key, or background service.
-- A fresh reviewer is required after worker-produced Guided or Measured work. Careful
-  mode—and high-risk Measured work—also requires observed read-only review isolation.
+- Fixed local Codex routes keep private work packets in local temporary files, pass them
+  only to the selected Codex process, then remove them after that process exits. An external
+  Morph provider can receive its bounded worker packet during inference when the user
+  explicitly configures that route; local packet handling does not make external processing
+  local. There is no analytics collection, extra network client, API key, or background service.
+- A fresh reviewer is required after worker-produced Guided, Measured, Morph, or
+  Constellation work. Careful mode—and high-risk Measured, Morph, or Constellation work—
+  also requires observed read-only review isolation.
 
 ## Updating and the 3.0 migration
 
@@ -312,6 +359,8 @@ These commands do not delete your downloaded repository or project files.
 | The plugin does not appear | Start a new Codex task, then run codex plugin list --marketplace astral-orchestrator. |
 | Setup reports a profile conflict | Astral Orchestrator will not overwrite a customized native profile. Keep it and use the bundled exact-process route, or resolve the difference deliberately before rerunning optional setup. |
 | A route cannot be proven | Confirm the bundled launcher dry run can prove the exact role, model, and effort. Reinstall the GitHub marketplace source or run `sh scripts/setup.sh --refresh` only if you want to restore native profiles; never accept another role, model, or effort as a fallback. |
+| A Morph worker fails | Check the separately configured provider/model and requested effort with its owner. Astral does not configure OpenCodex, credentials, services, or provider compatibility. |
+| Constellation will not fan out | Make each card independent with non-overlapping ownership, or continue with the serial Guided-style fallback. The primary consumes one advertised slot. |
 | An effort value is rejected | Pick a supported value available to your account; max and ultra are not available everywhere. |
 | Setup cannot find Codex or Python | Install or update Codex and use Python 3.11 or newer, then rerun the dry run. |
 
@@ -324,9 +373,11 @@ pinned lane and demanding evidence before handoff.
 
 ### Can I use only one model?
 
-Quick mode uses the verified Sol primary. Guided, Careful, and Measured require all three
+Quick mode uses the verified Sol primary. Guided, Careful, and Measured require the three
 specified models when bounded execution or independent review is needed; there is no
-silent model substitution.
+silent model substitution. Morph can use a user-selected worker model only after an
+explicit opt-in, while Constellation defaults to non-Sol workers and retains one Sol
+primary and one fresh Sol reviewer.
 
 ### Are my effort settings lost during an update?
 

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,0 +1,45 @@
+# Portability boundary
+
+Astral Orchestrator 3.3.0 ships two additive manifests in one package:
+
+- `plugin.json` is the root Agent Plugins 1.0 manifest. It supplies portable package
+  identity and lets compatible hosts discover the `skills/astral-orchestrator/SKILL.md`
+  skill through the fixed `skills/` location.
+- `.codex-plugin/plugin.json` remains the Codex/OpenAI manifest. It preserves the
+  existing Codex interface metadata and fixed route integration.
+
+The [Agent Plugins 1.0 specification](https://agent-plugins.org/specification) and its
+[plugin manifest guide](https://agent-plugins.org/plugin-authors/manifest) standardize
+skills and MCP discovery only, not agents, concurrency, model selection, or reasoning
+effort. A root portable manifest therefore contains only
+the closed metadata fields defined by its canonical schema; it does not declare Codex
+interface or routing fields. The [skills guide](https://agent-plugins.org/plugin-authors/skills)
+defines immediate `skills/*/SKILL.md` discovery, and the package verifier confirms that
+each discovered skill resolves within the package rather than through a symlink escape.
+
+## Host capabilities, not names
+
+The [compatible-client directory](https://agent-plugins.org/compatible-clients) currently
+lists VS Code, Cursor, GitHub Copilot, ChatGPT/Codex, and Kiro. It also says clients can
+adopt component types incrementally. The list is evidence that those clients document
+some Agent Plugins components; it is not evidence that every client supports Astral
+Orchestrator’s model routing or multi-worker workflow.
+
+On a non-Codex host, only an explicitly requested Morph or Constellation route may run.
+Before doing so, Astral requires observable evidence of the capabilities the route needs:
+
+- choosing a specific provider/model and reporting the actual selected provider/model;
+- separate worker contexts for worker work and a fresh reviewer context;
+- a requested-versus-actual effort value, when the host exposes effort;
+- concurrent worker contexts for Constellation; and
+- a fresh reviewer context distinct from the primary and workers.
+
+If an exact model, effort, or fresh context cannot be observed, Astral does not label it
+Sol, Luna, Terra, or “fresh.” Morph stops when its minimum worker/reviewer capabilities
+are absent. An explicitly requested Constellation can instead use its documented serial
+portable fallback only when the other required capabilities are proven; it never pretends
+that serial work was concurrent.
+
+Codex remains the only route in this package with fixed Sol/Luna/Terra profiles and
+automatic local primary-route evidence. The portable package adds a discovery surface; it
+does not change, weaken, or generalize those Codex guarantees.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,11 +1,13 @@
-# Spec: Astral Orchestrator v3.2
+# Spec: Astral Orchestrator v3.3
 
 ## Objective
 
-Provide a beginner-friendly Codex plugin that delivers observable model-routed
+Provide a beginner-friendly Codex plugin with an additive portable skill package that delivers observable model-routed
 orchestration. A Sol task leads, assigns bounded work to Luna or Terra based on the work,
-integrates and verifies the result, then uses a fresh Sol reviewer. Each lane's reasoning
-effort is configurable without editing profiles.
+integrates and verifies the result, then uses a fresh Sol reviewer. Explicit opt-in Morph
+can route only a bounded worker to a user-selected model, and explicit opt-in Constellation
+can fan out independent cards within verified capacity. Each fixed lane's reasoning effort
+is configurable without editing profiles.
 
 The user should not need to understand TOML files, runtime logs, or agent APIs. Two
 GitHub marketplace commands install the plugin and its bundled exact-process launcher.
@@ -21,11 +23,18 @@ recorded.
 
 Version 3.2 adds explicit opt-in Measured mode: one canonical frozen work card, an
 owner-only non-secret local ledger, deterministic pinned-lane routing, and fresh review.
+The v3.2 package also documents explicit opt-in Morph and Constellation routes without a
+version bump: Sol remains the verified primary and final reviewer in every mode.
+
+Version 3.3.0 adds a root portable manifest alongside the existing Codex manifest. The
+portable package standardizes skill discovery only. On capable non-Codex hosts, an
+explicit Morph or Constellation route requires observable model, worker-context, and
+fresh-reviewer capabilities; it does not generalize fixed Codex lanes.
 
 ## Identity and migration
 
 Version 3.0.0 was the breaking identity migration from the former Project Pilot
-identifiers. The current product version is 3.2.0. The normalized plugin, marketplace,
+identifiers. The current product version is 3.3.0. The normalized plugin, marketplace,
 skill, and profile prefix is
 astral-orchestrator; TOML agent names use astral_orchestrator. Route evidence begins
 with ASTRAL_ORCHESTRATOR_ROUTE, and persistent effort settings live at
@@ -47,6 +56,13 @@ modified automatically.
    the same lane.
 6. The project homepage is https://github.com/Demonbane18/astral-orchestrator.
 7. The MIT-licensed Sol Advisor source may be adapted with preserved notice.
+8. Where `CODEX_THREAD_ID` and local rollout evidence are available, the bundled primary
+   checker can automatically inspect the current primary without reading rollout contents
+   itself or exposing prompts.
+9. OpenCodex, if a user chooses it for Morph, is installed and configured independently;
+   Astral neither modifies its configuration nor handles provider credentials.
+10. Non-Codex hosts may discover the portable skill but must expose each required Morph or
+    Constellation capability before the corresponding portable route can run.
 
 ## Route contract
 
@@ -56,6 +72,8 @@ modified automatically.
 | Narrow, repeatable, fully specified execution | Luna at configured effort (XHigh default) |
 | Context-heavy implementation, debugging, component/external integration, refactoring | Terra at configured effort (XHigh default) |
 | Fresh final review | Sol at configured reviewer effort (High default), with requested read-only sandbox |
+| Explicit Morph worker | User-selected native or `provider/model` worker at requested effort; Sol remains primary and reviewer |
+| Explicit Constellation first wave | Cost-aware non-Sol workers by default, only for independent ready cards within advertised capacity |
 
 The default efforts are Sol High, Luna XHigh, Terra XHigh, and reviewer Sol High.
 Per-lane overrides are stored outside the plugin cache. A custom worker or reviewer
@@ -69,17 +87,22 @@ only for fully specified narrow mechanical work with exact checks and no flags; 
 debugging, integration, cross-component, context-heavy, or moderate-ambiguity flag uses
 Terra. Ambiguous routing receives exactly one Luna and one Terra behaviorally read-only
 probe with the identical card; material disagreement defaults to Terra.
+Morph and Constellation are never auto-selected. Morph stores the exact worker model id
+and requested effort in each card, but does not claim that a provider accepted native
+effort semantics. Constellation starts only the independent first wave that fits the
+configured roster and host-advertised available slots after the primary uses one. It falls
+back to serial Guided-style routing when capacity or independence cannot be proven.
 
 ## Tech stack
 
-- Codex marketplace JSON and plugin manifest JSON
+- Codex marketplace JSON and plugin manifest JSON, plus a root portable manifest JSON
 - Markdown Codex skill and one-level reference files
 - Codex custom-agent TOML profiles
 - POSIX shell for setup, exact-copy installation, and verification
 - Python 3.11+ standard library for tests, exact-process launching, and allowlisted
   runtime evidence
 - No added API key, external service beyond Codex, analytics, direct network client, or
-  background process
+  background process; OpenCodex remains an optional user-owned route, not a dependency
 
 ## Commands
 
@@ -100,7 +123,16 @@ probe with the identical card; material disagreement defaults to Terra.
 - Agent reports are inspected and independently verified in the primary session.
 - Missing or mismatched role, model, or effort evidence stops the route; no silent
   fallback is allowed.
+- The primary checker returns allowlisted `match`, `mismatch`, or `unavailable` JSON and
+  exits zero only for the exact configured Sol route; only unavailable evidence may use
+  the one-time user-confirmation fallback.
 - Unsupported effort settings fail before a delegated Codex process starts.
+- Morph never changes the primary or final reviewer, and its requested effort is not a
+  claim of verified upstream-native effort semantics.
+- Constellation uses no extra Sol implementers by default and falls back to serial routing
+  unless it can prove independent ownership and available capacity.
+- Portable routes never claim fixed lane names, actual model/effort, concurrency, or fresh
+  review without observable host evidence.
 - Careful review cannot claim ship unless required read-only isolation is observed.
 - Measured uses an unpersisted Prepare step, one persisted freeze/preflight/route base,
   one or more numbered implementation/verification/review attempts, and Complete only
@@ -120,3 +152,7 @@ probe with the identical card; material disagreement defaults to Terra.
 8. A non-technical user can show, change, and reset every lane's effort independently.
 9. A Measured run keeps one canonical card, reproducible safe state, exact routing
    evidence, fresh verification after fixes, and a new fresh reviewer.
+10. Morph and Constellation remain explicit opt-ins with the fixed Sol primary and reviewer
+    guarantees preserved.
+11. The root portable manifest and fixed `skills/` discovery are verified without changing
+    the existing Codex/OpenAI manifest or route contract.

--- a/plugins/astral-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/astral-orchestrator/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "astral-orchestrator",
-  "version": "3.2.0",
-  "description": "Beginner-friendly orchestration with Quick, Guided, Careful, and explicit opt-in Measured modes for planning, delegating, verifying, and reviewing project work in Codex.",
+  "version": "3.3.0",
+  "description": "Beginner-friendly orchestration with Quick, Guided, Careful, Measured, and explicit opt-in Morph and Constellation modes for planning, delegating, verifying, and reviewing project work in Codex.",
   "author": {
     "name": "Demonbane18"
   },
@@ -19,7 +19,7 @@
   "interface": {
     "displayName": "Astral Orchestrator",
     "shortDescription": "Simple, risk-aware delivery for any project.",
-    "longDescription": "Astral Orchestrator offers Quick, Guided, Careful, and explicit opt-in Measured modes: Quick keeps tiny work in Sol with self-review; Guided, Careful, and Measured route bounded work to pinned Luna or Terra lanes at their configured efforts, verify changes, and request a fresh Sol reviewer. Measured records local evidence and never runs automatically.",
+    "longDescription": "Astral Orchestrator offers Quick, Guided, Careful, Measured, Morph, and Constellation modes: Quick keeps tiny work in Sol with self-review; Guided, Careful, and Measured keep fixed Luna/Terra worker routes at their configured efforts and a fresh Sol reviewer. Explicit opt-in Morph uses a user-selected worker model while Sol remains primary and reviewer; explicit opt-in Constellation fan-outs only independent cards within host capacity. Each explicit opt-in mode never runs automatically.",
     "developerName": "Astral Orchestrator Contributors",
     "category": "Productivity",
     "brandColor": "#0B1020",
@@ -30,9 +30,9 @@
     "composerIcon": "./skills/astral-orchestrator/assets/icon.png",
     "logo": "./skills/astral-orchestrator/assets/icon.png",
     "defaultPrompt": [
-      "Use Astral Orchestrator in Guided mode (the default) to complete this request and verify the result.",
-      "Use Astral Orchestrator in Measured mode for this evidence-oriented request.",
-      "Use Astral Orchestrator in Careful mode for this risky change."
+      "Use Astral Orchestrator in Guided mode (default); choose Quick or Careful when the task warrants it.",
+      "Use Astral Orchestrator in Measured or Morph mode for this explicit opt-in request.",
+      "Use Astral Orchestrator in Constellation mode for this explicit opt-in independent-card request."
     ]
   }
 }

--- a/plugins/astral-orchestrator/plugin.json
+++ b/plugins/astral-orchestrator/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "astral-orchestrator",
+  "version": "3.3.0",
+  "description": "A six-mode project-delivery skill with explicit Morph and Constellation worker routes for capable hosts.",
+  "author": {
+    "name": "Demonbane18",
+    "url": "https://github.com/Demonbane18"
+  },
+  "homepage": "https://github.com/Demonbane18/astral-orchestrator",
+  "repository": "https://github.com/Demonbane18/astral-orchestrator",
+  "license": "MIT",
+  "keywords": [
+    "orchestration",
+    "agent-skills",
+    "project-management",
+    "verification",
+    "review"
+  ]
+}

--- a/plugins/astral-orchestrator/scripts/check-primary.py
+++ b/plugins/astral-orchestrator/scripts/check-primary.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Verify the current primary route from allowlisted local runtime evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from effort_settings import (  # noqa: E402
+    ALLOWED_EFFORTS,
+    EffortSettingsError,
+    default_settings_path,
+    load_efforts,
+)
+
+
+EXPECTED_MODEL = "gpt-5.6-sol"
+THREAD_ID_PATTERN = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
+MODEL_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}")
+ALLOWED_STATUSES = {"match", "mismatch", "invalid", "unavailable"}
+ALLOWED_REASONS = {
+    "primary-route-match",
+    "primary-route-mismatch",
+    "thread-id-invalid",
+    "thread-id-unavailable",
+    "sessions-directory-unavailable",
+    "rollout-unavailable",
+    "rollout-ambiguous",
+    "runtime-evidence-invalid",
+    "effort-settings-invalid",
+}
+
+
+def fail(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check whether the current primary is the configured Astral Sol route."
+    )
+    parser.add_argument(
+        "--thread-id",
+        default=os.environ.get("CODEX_THREAD_ID"),
+        help="Codex thread id; defaults to CODEX_THREAD_ID.",
+    )
+    parser.add_argument(
+        "--sessions-dir",
+        type=Path,
+        help="Override the Codex sessions directory (intended for local inspection).",
+    )
+    parser.add_argument(
+        "--settings-file",
+        type=Path,
+        default=default_settings_path(),
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args()
+
+
+def resolve_sessions_dir(configured: Path | None) -> Path:
+    """Match the bundled inspector's default session location without reading rollouts."""
+    if configured is not None:
+        return configured
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "sessions"
+    return Path.home() / ".codex" / "sessions"
+
+
+def find_rollouts(sessions_dir: Path, thread_id: str) -> list[Path] | None:
+    """Count only matching rollout filenames; rollout contents stay inspector-owned."""
+    try:
+        if not sessions_dir.is_dir():
+            return None
+        return [
+            path
+            for path in sessions_dir.rglob(f"rollout-*-{thread_id}.jsonl")
+            if path.is_file()
+        ]
+    except OSError:
+        return None
+
+
+def emit(
+    status: str,
+    reason: str,
+    expected_effort: str,
+    *,
+    thread_id: str | None = None,
+    observed_model: str | None = None,
+    observed_effort: str | None = None,
+) -> None:
+    if status not in ALLOWED_STATUSES or reason not in ALLOWED_REASONS:
+        fail("internal primary-evidence contract error")
+
+    evidence: dict[str, str] = {
+        "expected_effort": expected_effort,
+        "expected_model": EXPECTED_MODEL,
+        "reason": reason,
+        "status": status,
+    }
+    if thread_id is not None:
+        evidence["thread_id"] = thread_id
+    if observed_model is not None:
+        evidence["observed_model"] = observed_model
+    if observed_effort is not None:
+        evidence["observed_effort"] = observed_effort
+    print(json.dumps(evidence, separators=(",", ":"), sort_keys=True))
+
+
+def main() -> int:
+    if sys.version_info < (3, 11):
+        fail("Python 3.11 or newer is required.")
+
+    args = parse_args()
+    try:
+        efforts, _settings_file_present = load_efforts(args.settings_file)
+    except EffortSettingsError:
+        emit("invalid", "effort-settings-invalid", "unknown")
+        return 1
+    expected_effort = efforts["orchestrator"]
+
+    thread_id = args.thread_id
+    if thread_id is None:
+        emit("unavailable", "thread-id-unavailable", expected_effort)
+        return 1
+    if not isinstance(thread_id, str) or not THREAD_ID_PATTERN.fullmatch(thread_id):
+        emit("invalid", "thread-id-invalid", expected_effort)
+        return 1
+
+    sessions_dir = resolve_sessions_dir(args.sessions_dir)
+    rollouts = find_rollouts(sessions_dir, thread_id)
+    if rollouts is None:
+        emit(
+            "unavailable",
+            "sessions-directory-unavailable",
+            expected_effort,
+            thread_id=thread_id,
+        )
+        return 1
+    if not rollouts:
+        emit("unavailable", "rollout-unavailable", expected_effort, thread_id=thread_id)
+        return 1
+    if len(rollouts) != 1:
+        emit("invalid", "rollout-ambiguous", expected_effort, thread_id=thread_id)
+        return 1
+
+    command = [
+        "sh",
+        str(SCRIPT_DIR / "inspect-agent-runtime.sh"),
+        "--sessions-dir",
+        str(sessions_dir),
+        "--thread-id",
+        thread_id,
+    ]
+    inspected = subprocess.run(command, check=False, capture_output=True, text=True)
+    if inspected.returncode != 0:
+        emit(
+            "invalid",
+            "runtime-evidence-invalid",
+            expected_effort,
+            thread_id=thread_id,
+        )
+        return 1
+
+    try:
+        observed = json.loads(inspected.stdout)
+    except json.JSONDecodeError:
+        emit(
+            "invalid",
+            "runtime-evidence-invalid",
+            expected_effort,
+            thread_id=thread_id,
+        )
+        return 1
+
+    if not isinstance(observed, dict):
+        emit(
+            "invalid",
+            "runtime-evidence-invalid",
+            expected_effort,
+            thread_id=thread_id,
+        )
+        return 1
+
+    observed_thread_id = observed.get("thread_id")
+    observed_model = observed.get("model")
+    observed_effort = observed.get("effort")
+    if (
+        observed_thread_id != thread_id
+        or not isinstance(observed_model, str)
+        or not MODEL_PATTERN.fullmatch(observed_model)
+        or not isinstance(observed_effort, str)
+        or observed_effort not in ALLOWED_EFFORTS
+    ):
+        emit(
+            "invalid",
+            "runtime-evidence-invalid",
+            expected_effort,
+            thread_id=thread_id,
+        )
+        return 1
+
+    matches = observed_model == EXPECTED_MODEL and observed_effort == expected_effort
+    emit(
+        "match" if matches else "mismatch",
+        "primary-route-match" if matches else "primary-route-mismatch",
+        expected_effort,
+        thread_id=thread_id,
+        observed_model=observed_model,
+        observed_effort=observed_effort,
+    )
+    return 0 if matches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/astral-orchestrator/scripts/inspect-agent-runtime.sh
+++ b/plugins/astral-orchestrator/scripts/inspect-agent-runtime.sh
@@ -165,7 +165,24 @@ turns = [
     for item in records
     if item.get("type") == "turn_context" and isinstance(item.get("payload"), dict)
 ]
-if len(sessions) != 1:
+if not sessions:
+    fail("metadata for the requested task is missing or ambiguous.")
+session_identity_fields = (
+    "id",
+    "parent_thread_id",
+    "forked_from_id",
+    "agent_nickname",
+    "agent_path",
+    "model_provider",
+)
+session_identity = {
+    field: sessions[0].get(field) for field in session_identity_fields
+}
+if any(
+    {field: candidate.get(field) for field in session_identity_fields}
+    != session_identity
+    for candidate in sessions[1:]
+):
     fail("metadata for the requested task is missing or ambiguous.")
 if not turns:
     fail("turn context is missing.")

--- a/plugins/astral-orchestrator/scripts/run-morph-agent.py
+++ b/plugins/astral-orchestrator/scripts/run-morph-agent.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Launch one explicit Morph worker through the user's existing Codex route."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from effort_settings import ALLOWED_EFFORTS  # noqa: E402
+
+
+MODEL_CHARACTERS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:/-"
+)
+MAX_MODEL_LENGTH = 256
+MORPH_DEVELOPER_INSTRUCTIONS = """\
+You are an Astral Orchestrator Morph implementation worker. Execute only the bounded
+work card provided on standard input. Preserve unrelated and concurrent edits, surface
+material ambiguity instead of redesigning requirements or architecture, and report
+the actual changes and checks. Perform the work directly; you must not spawn or delegate
+to another agent.
+"""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_shared_prompt_reader():
+    """Load the established private-packet checks without importing a new dependency."""
+    specification = importlib.util.spec_from_file_location(
+        "astral_orchestrator_run_agent_shared", SCRIPT_DIR / "run-agent.py"
+    )
+    if specification is None or specification.loader is None:
+        fail("the bundled private-packet validator is unavailable")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    reader = getattr(module, "read_prompt", None)
+    if not callable(reader):
+        fail("the bundled private-packet validator is invalid")
+    return reader
+
+
+def valid_model(value: str) -> str:
+    parts = value.split("/")
+    if (
+        not value
+        or len(value) > MAX_MODEL_LENGTH
+        or value[0] in ".:/-"
+        or any(not part for part in parts)
+        or any(character not in MODEL_CHARACTERS for character in value)
+    ):
+        raise argparse.ArgumentTypeError(
+            "model must be a non-secret provider/model or native model identifier"
+        )
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run one explicit, user-selected Astral Morph worker."
+    )
+    parser.add_argument("--model", required=True, type=valid_model)
+    parser.add_argument("--effort", required=True, choices=ALLOWED_EFFORTS)
+    parser.add_argument("--workdir", required=True)
+    parser.add_argument("--prompt-file", required=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print allowlisted Morph route settings without starting Codex.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.version_info < (3, 11):
+        fail("Python 3.11 or newer is required.")
+
+    args = parse_args()
+    prompt_reader = load_shared_prompt_reader()
+    prompt = prompt_reader(Path(args.prompt_file).expanduser())
+
+    workdir = Path(args.workdir).expanduser().resolve()
+    if not workdir.is_dir():
+        fail(f"workdir must be an existing directory: {workdir}")
+
+    evidence = {
+        "effort_semantics": "requested-only",
+        "model": args.model,
+        "prompt_bytes": len(prompt),
+        "requested_effort": args.effort,
+        "route": "morph",
+        "sandbox": "workspace-write",
+        "verified_upstream_native_effort": "unverified",
+        "workdir": str(workdir),
+    }
+    if args.dry_run:
+        print(json.dumps(evidence, separators=(",", ":"), sort_keys=True))
+        return 0
+
+    codex = shutil.which("codex")
+    if codex is None:
+        fail("the codex command is unavailable")
+
+    command = [
+        codex,
+        "exec",
+        "--model",
+        args.model,
+        "-c",
+        f"model_reasoning_effort={json.dumps(args.effort)}",
+        "-c",
+        f"developer_instructions={json.dumps(MORPH_DEVELOPER_INSTRUCTIONS)}",
+        "--sandbox",
+        "workspace-write",
+        "--skip-git-repo-check",
+        "--cd",
+        str(workdir),
+        "-",
+    ]
+    print(
+        "ASTRAL_ORCHESTRATOR_ROUTE "
+        + json.dumps(evidence, separators=(",", ":"), sort_keys=True),
+        flush=True,
+    )
+    result = subprocess.run(command, input=prompt, check=False)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/astral-orchestrator/scripts/verify.sh
+++ b/plugins/astral-orchestrator/scripts/verify.sh
@@ -11,15 +11,21 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd) || exit 1
 plugin_dir=$(CDPATH= cd "$script_dir/.." && pwd) || exit 1
 repo_root=$(CDPATH= cd "$plugin_dir/../.." && pwd) || exit 1
 manifest=$plugin_dir/.codex-plugin/plugin.json
+portable_manifest=$plugin_dir/plugin.json
 skill=$plugin_dir/skills/astral-orchestrator/SKILL.md
 modes=$plugin_dir/skills/astral-orchestrator/references/modes-and-risk.md
 templates=$plugin_dir/skills/astral-orchestrator/references/work-templates.md
 routing=$plugin_dir/skills/astral-orchestrator/references/routing-and-preflight.md
 measured=$plugin_dir/skills/astral-orchestrator/references/measured-mode.md
+morph=$plugin_dir/skills/astral-orchestrator/references/morph-mode.md
+constellation=$plugin_dir/skills/astral-orchestrator/references/constellation-mode.md
+portable_hosts=$plugin_dir/skills/astral-orchestrator/references/portable-hosts.md
 agent_dir=$plugin_dir/agents
 installer=$plugin_dir/scripts/install-agents.sh
 inspector=$plugin_dir/scripts/inspect-agent-runtime.sh
+primary_checker=$plugin_dir/scripts/check-primary.py
 launcher=$plugin_dir/scripts/run-agent.py
+morph_launcher=$plugin_dir/scripts/run-morph-agent.py
 effort_settings=$plugin_dir/scripts/effort_settings.py
 effort_configurator=$plugin_dir/scripts/configure-effort.py
 benchmark_scorecard=$plugin_dir/scripts/benchmark-scorecard.py
@@ -39,28 +45,29 @@ cmp -s "$canonical_license" "$plugin_license" || fail "distributable notice diff
 cmp -s "$canonical_notice" "$plugin_notice" || fail "distributable notice differs from repository root: NOTICE.md"
 grep -Fq "($canonical_improvements_url)" "$canonical_notice" || fail "canonical NOTICE must link to the repository improvements document"
 
-for required in "$manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$installer" "$inspector" "$launcher" "$effort_settings" "$effort_configurator" "$benchmark_scorecard" "$effort_wrapper"; do
+for required in "$manifest" "$portable_manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$morph" "$constellation" "$portable_hosts" "$installer" "$inspector" "$primary_checker" "$launcher" "$morph_launcher" "$effort_settings" "$effort_configurator" "$benchmark_scorecard" "$effort_wrapper"; do
   [ -f "$required" ] || fail "required file is missing: $required"
 done
 
 command -v python3 >/dev/null 2>&1 || fail "Python 3.11 or newer is required for repository verification."
 python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1 || fail "Python 3.11 or newer is required for repository verification."
 
-python3 - "$manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$agent_dir" "$marketplace" <<'PY'
+python3 - "$manifest" "$portable_manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$morph" "$constellation" "$portable_hosts" "$agent_dir" "$marketplace" <<'PY'
 import json
+import re
 import sys
 import tomllib
 from pathlib import Path
 
-manifest_path, skill_path, modes_path, templates_path, routing_path, measured_path, agent_dir, marketplace_path = map(
+manifest_path, portable_manifest_path, skill_path, modes_path, templates_path, routing_path, measured_path, morph_path, constellation_path, portable_hosts_path, agent_dir, marketplace_path = map(
     Path, sys.argv[1:]
 )
 
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 if manifest.get("name") != "astral-orchestrator":
     raise SystemExit("manifest name must be astral-orchestrator")
-if manifest.get("version") != "3.2.0":
-    raise SystemExit("manifest version must be Astral Orchestrator v3.2.0")
+if manifest.get("version") != "3.3.0":
+    raise SystemExit("manifest version must be Astral Orchestrator v3.3.0")
 if manifest.get("skills") != "./skills/":
     raise SystemExit("manifest skills path must be ./skills/")
 if manifest.get("license") != "MIT":
@@ -72,6 +79,62 @@ if manifest.get("homepage") != "https://github.com/Demonbane18/astral-orchestrat
 repository = manifest.get("repository")
 if repository != "https://github.com/Demonbane18/astral-orchestrator":
     raise SystemExit("manifest repository metadata is invalid")
+
+portable_manifest = json.loads(portable_manifest_path.read_text(encoding="utf-8"))
+portable_fields = {
+    "$schema", "name", "version", "description", "author", "homepage", "repository",
+    "license", "keywords", "extensions",
+}
+if not isinstance(portable_manifest, dict) or set(portable_manifest) - portable_fields:
+    raise SystemExit("portable manifest must use only closed Agent Plugins top-level fields")
+if portable_manifest.get("$schema") != "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json":
+    raise SystemExit("portable manifest schema must be the canonical Agent Plugins v1.0.0 schema")
+if portable_manifest.get("name") != "astral-orchestrator":
+    raise SystemExit("portable manifest name must be astral-orchestrator")
+if not re.fullmatch(r"(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?", portable_manifest["name"]):
+    raise SystemExit("portable manifest name violates the Agent Plugins name contract")
+if portable_manifest.get("version") != manifest.get("version"):
+    raise SystemExit("Codex and portable manifest versions must match")
+if any(field in portable_manifest for field in ("skills", "interface")):
+    raise SystemExit("portable manifest must rely on fixed discovery, not Codex fields")
+for field in ("description", "homepage", "repository", "license"):
+    if not isinstance(portable_manifest.get(field), str):
+        raise SystemExit(f"portable manifest {field} must be a string")
+author = portable_manifest.get("author")
+if not isinstance(author, dict) or set(author) - {"name", "email", "url"} or any(
+    not isinstance(value, str) for value in author.values()
+):
+    raise SystemExit("portable manifest author must be a closed object of strings")
+if not isinstance(portable_manifest.get("keywords"), list) or any(
+    not isinstance(value, str) for value in portable_manifest["keywords"]
+):
+    raise SystemExit("portable manifest keywords must be strings")
+if "extensions" in portable_manifest and (
+    not isinstance(portable_manifest["extensions"], dict)
+    or any(not isinstance(value, dict) for value in portable_manifest["extensions"].values())
+):
+    raise SystemExit("portable manifest extensions must map namespaces to objects")
+
+portable_root = portable_manifest_path.parent.resolve()
+skills_root = portable_root / "skills"
+try:
+    skills_root.resolve().relative_to(portable_root)
+except ValueError:
+    raise SystemExit("portable skills directory resolves outside the package")
+if not skills_root.is_dir():
+    raise SystemExit("portable fixed skills path must be a directory")
+for child in skills_root.iterdir():
+    skill_file = child / "SKILL.md"
+    if not skill_file.exists():
+        continue
+    if not skill_file.is_file():
+        raise SystemExit(f"portable discovered skill is not a regular file: {skill_file.name}")
+    try:
+        skill_file.resolve().relative_to(portable_root)
+    except ValueError:
+        raise SystemExit(f"portable discovered skill escapes the package: {child.name}")
+if not (skills_root / "astral-orchestrator" / "SKILL.md").is_file():
+    raise SystemExit("portable fixed skills path is missing Astral Orchestrator")
 
 prompts = manifest.get("interface", {}).get("defaultPrompt")
 if not isinstance(prompts, list) or not 1 <= len(prompts) <= 3:
@@ -87,6 +150,8 @@ for required_text in (
     "Guided (default)",
     "Careful",
     "Measured",
+    "Morph",
+    "Constellation",
     "Sol High",
     "astral_orchestrator_luna_implementer",
     "astral_orchestrator_terra_implementer",
@@ -100,6 +165,21 @@ modes = modes_path.read_text(encoding="utf-8")
 for required_text in ("Low risk", "Medium risk", "High risk", "User confirmation gate"):
     if required_text not in modes:
         raise SystemExit(f"risk guide is missing: {required_text}")
+
+morph = morph_path.read_text(encoding="utf-8")
+for required_text in ("explicit opt-in", "OpenCodex is optional", "requested effort", "fresh Sol reviewer"):
+    if required_text not in morph:
+        raise SystemExit(f"Morph guide is missing: {required_text}")
+
+constellation = constellation_path.read_text(encoding="utf-8")
+for required_text in ("explicit opt-in", "first wave concurrently", "available slots", "fresh exact Sol reviewer"):
+    if required_text not in constellation:
+        raise SystemExit(f"Constellation guide is missing: {required_text}")
+
+portable_hosts = " ".join(portable_hosts_path.read_text(encoding="utf-8").lower().split())
+for required_text in ("observable", "separate worker context", "fresh reviewer context", "serial portable fallback"):
+    if required_text not in portable_hosts:
+        raise SystemExit(f"portable-host guide is missing: {required_text}")
 
 templates = templates_path.read_text(encoding="utf-8")
 for required_text in ("Work card", "Implementation delegation", "Fresh review"):
@@ -171,7 +251,7 @@ if marketplace_path.is_file():
     if len(entries) != 1 or entries[0].get("name") != "astral-orchestrator":
         raise SystemExit("marketplace must contain exactly one astral-orchestrator entry")
 
-for path in (manifest_path, skill_path, modes_path, templates_path, routing_path, measured_path, *agent_dir.glob("*.toml")):
+for path in (manifest_path, portable_manifest_path, skill_path, modes_path, templates_path, routing_path, measured_path, morph_path, constellation_path, portable_hosts_path, *agent_dir.glob("*.toml")):
     text = path.read_text(encoding="utf-8")
     if "[TODO" in text or "YOUR-NAME" in text:
         raise SystemExit(f"placeholder remains in {path}")
@@ -182,6 +262,8 @@ sh -n "$installer"
 sh -n "$inspector"
 sh -n "$effort_wrapper"
 python3 "$launcher" --help >/dev/null
+python3 "$primary_checker" --help >/dev/null
+python3 "$morph_launcher" --help >/dev/null
 python3 "$effort_configurator" --help >/dev/null
 python3 "$benchmark_scorecard" --help >/dev/null
 

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: astral-orchestrator
-description: "Orchestrate project work with a Sol lead, model-pinned Luna and Terra implementation lanes, configurable reasoning effort, and a fresh Sol reviewer. Use when the user invokes Astral Orchestrator, asks for real multi-agent delegation, wants to change Astral Orchestrator effort levels, wants a request built or fixed end to end, requests risk-aware execution, or wants model-routed implementation with verified results."
+description: "Orchestrate project work with a Sol lead, fixed Luna and Terra lanes, explicit opt-in Morph and Constellation workers, configurable reasoning effort, and a fresh Sol reviewer. Use when the user invokes Astral Orchestrator, asks for real multi-agent delegation, wants to change Astral Orchestrator effort levels, wants a request built or fixed end to end, requests risk-aware execution, or wants model-routed implementation with verified results."
 ---
 
 # Astral Orchestrator
@@ -11,12 +11,31 @@ workers for bounded execution; and keep the process understandable to a non-tech
 user.
 
 Read [references/modes-and-risk.md](references/modes-and-risk.md) for mode, risk, and
-confirmation decisions. Before spawning any lane, read
-[references/routing-and-preflight.md](references/routing-and-preflight.md). Before
-delegating or reviewing, read
-[references/work-templates.md](references/work-templates.md).
+confirmation decisions. Before spawning a Codex lane, read
+[references/routing-and-preflight.md](references/routing-and-preflight.md) and
+[references/work-templates.md](references/work-templates.md). Before a portable worker,
+read `portable-hosts.md` and the work templates instead.
 When the user explicitly names Measured, also read
 [references/measured-mode.md](references/measured-mode.md).
+When the user explicitly names Morph, also read
+[references/morph-mode.md](references/morph-mode.md). When the user explicitly names Constellation,
+also read [references/constellation-mode.md](references/constellation-mode.md).
+
+## Host boundary
+
+First identify whether the host is Codex from observable host/runtime evidence, not
+from a user guess. On Codex, use the fixed routes and bundled preflight below. On a
+non-Codex Agent Plugins-compatible host, load
+[references/portable-hosts.md](references/portable-hosts.md) before doing anything beyond
+mode selection. Only explicitly selected Morph or Constellation portable routes may run
+there. Do not attempt Codex scripts, `CODEX_THREAD_ID`, or Astral agent names on a
+non-Codex host.
+
+Portable routes require observable host capabilities for model selection, separate worker
+contexts, a fresh reviewer context, and—only for concurrent Constellation—available
+concurrency. Record the actual and requested provider, model, and effort separately. If
+the exact model, effort, or fresh context cannot be proven, stop or use the documented
+serial portable Constellation fallback; never claim Sol/Luna/Terra unless observed.
 
 ## 1. Choose the mode and risk
 
@@ -34,14 +53,20 @@ When the user explicitly names Measured, also read
   checks, keep a non-secret resumable local ledger, and use planning probes only when
   Luna/Terra selection is ambiguous. Measured is never auto-selected; recommend Guided
   for normal work. Its detailed state machine is in the Measured reference.
+- **Morph (explicit opt-in)** — a user-selected routed or native worker model for a
+  bounded card. Sol remains the configured primary and the exact fresh Sol reviewer
+  remains required. Read the Morph reference before launch.
+- **Constellation (explicit opt-in)** — a capacity-limited concurrent first wave for independently
+  owned ready cards. Sol remains one primary and one fresh reviewer; no extra Sol
+  implementers are spawned by default. Read the Constellation reference before launch.
 
 Honor an explicit mode unless its safeguards are too weak for the observed risk. Raise
 the safeguards when necessary and explain why in one sentence. Never lower Careful
 without permission.
 
-## 2. Prove the orchestration preflight
+## 2. Prove the Codex orchestration preflight
 
-Astral Orchestrator v3 uses these exact models. Their default efforts are:
+On Codex, Astral Orchestrator v3 uses these exact models. Their default efforts are:
 
 - main orchestrator: **Sol High** (`gpt-5.6-sol`, reasoning `high`);
 - focused worker: `astral_orchestrator_luna_implementer` (Luna XHigh);
@@ -50,13 +75,16 @@ Astral Orchestrator v3 uses these exact models. Their default efforts are:
 
 Resolve the bundled `../../scripts/configure-effort.py` and run it with `--show --json`
 to obtain the effective effort for all four lanes. Missing settings mean the defaults
-above. For every mode, verify that the primary session is `gpt-5.6-sol` at the configured
-orchestrator effort. Prefer observable runtime metadata. If the host does not expose it,
-ask the user once to confirm the model and effort; record that as **user-confirmed**, not
-observed evidence. A changed orchestrator setting applies to a new task, not the task
+above. For every mode, resolve and run `../../scripts/check-primary.py` first. It uses the
+host's local rollout inspector and `CODEX_THREAD_ID` when available, then exits zero only
+when the observed primary is `gpt-5.6-sol` at the configured orchestrator effort. If its
+allowlisted JSON says unavailable, ask the user once to confirm the model and effort;
+record that as **user-confirmed**, not observed evidence. The checker never asks the user
+itself. A `mismatch` or `invalid` result blocks the route; manual confirmation cannot
+override either one. A changed orchestrator setting applies to a new task, not the task
 already running.
 
-For Guided, Careful, and Measured work, select one of two exact routes. First run the
+For Guided, Careful, and Measured work, select one of two exact fixed routes. First run the
 bundled profile installer's exact `--check`. A pass permits native selection only when
 the host exposes the exact role and its native profile effort equals the configured
 effort. When that check reports missing or different native profiles, or the host cannot
@@ -66,6 +94,10 @@ effort and shipped role instructions. Missing or different native profiles force
 exact-process route; they do not permit substitution or make optional setup required.
 Stop only when neither exact route can be proven. A blocking preflight ends the current
 turn. Never silently lower an unsupported effort.
+
+Morph and Constellation retain this exact Sol primary preflight and fresh Sol review. Their worker
+rules are explicit opt-ins defined only in their dedicated references; never treat either
+as permission to change the primary or final-review model.
 
 When the user explicitly asks to show or change effort settings, run the configuration
 script. Preserve unspecified lanes and report the resulting four values. Use `--reset`
@@ -96,7 +128,9 @@ return one direct question immediately. Do not wait silently in the same turn.
 
 For Guided or Careful work, split execution into the fewest useful non-overlapping work
 cards. Measured freezes exactly one canonical work card; it may describe multiple bounded
-items inside that card, but one selected lane owns all edits. Keep requirements,
+items inside that card, but one selected lane owns all edits. Morph uses a separately
+selected exact worker model only for its bounded card. Constellation may fan out only cards proven
+independent by its reference. Keep requirements,
 architecture, task decomposition, acceptance decisions, and cross-lane integration in
 the Sol primary session at its configured effort.
 
@@ -121,7 +155,8 @@ directly, and must not spawn or delegate further.
 Parallelize only independent cards with non-overlapping ownership. Run dependent work
 or shared-file edits serially. Do not spawn agents merely to make the run look busy.
 Guided, Careful, and Measured implementation must use at least one pinned worker whenever bounded
-execution exists; answer-only, planning-only, and blocked requests need no worker.
+execution exists; answer-only, planning-only, and blocked requests need no worker. Morph
+and Constellation use only their explicit worker rules and never weaken Careful safeguards.
 
 ## 5. Integrate and verify
 
@@ -147,6 +182,8 @@ pinned lane, rerun affected checks, and inspect the result again.
   isolation before accepting its independent review.
 - **Measured:** use the normal fresh Sol reviewer after the selected worker. High-risk
   Measured work also inherits Careful confirmation and observed read-only isolation.
+- **Morph and Constellation:** use the normal fresh exact Sol reviewer after integrated worker
+  changes. Careful risk still requires observed read-only isolation.
 
 Give the fresh reviewer only the outcome, acceptance conditions, boundaries, complete
 change set, and verification evidence. Accept exactly one verdict: **ship**,

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/agents/openai.yaml
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Sol-led, model-routed delivery for any project"
   icon_small: "./assets/icon.png"
   icon_large: "./assets/icon.png"
-  default_prompt: "Use $astral-orchestrator in Guided mode (the default); choose Measured mode only for a local evidence-oriented run."
+  default_prompt: "Use $astral-orchestrator in Guided (default); choose Quick, Careful, Measured, Morph, or Constellation only when named."

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/constellation-mode.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/constellation-mode.md
@@ -1,0 +1,59 @@
+# Constellation mode
+
+Constellation is an explicit opt-in: use it only when the user explicitly names it. Constellation has one configured
+Sol primary and one fresh Sol reviewer on its exact route. It is a constrained fan-out for independently
+owned cards, not a request to fill every available slot or to replace Sol’s integration role.
+
+## Prove that a concurrent first wave is safe
+
+Before launching, Sol must write a complete card for every candidate and prove all of the
+following:
+
+- each ready card has an independent outcome and non-overlapping file and system ownership;
+- no card needs another card’s output, interface decision, confirmation, or verification;
+- every worker has an exact model and requested/configured effort route it can use;
+- the host-advertised available slots are known; the primary consumes one slot;
+- the configured model roster has enough suitable, cost-aware non-Sol workers.
+
+Launch the first wave concurrently only after those facts are recorded. Its maximum worker
+count is the minimum of ready independent cards, suitable configured roster entries, and
+the host-advertised available slots minus the primary’s one slot. Do not hard-code four or
+five simultaneous children. Do not spawn extra Sol implementers by default; reserve Sol
+for the primary and fresh review, and prefer cost-aware non-Sol workers.
+
+If independence, ownership, ready status, model availability, or capacity cannot be
+proven, fall back to serial Guided-style routing. The fallback keeps the same work cards,
+exact routes, verification, and review; it merely removes unsupported concurrency.
+
+## Routing and integration
+
+Use Luna or Terra for ordinary fixed-route cards. A card that explicitly needs a
+user-selected routed model follows Morph mode and includes its exact model id and requested
+effort. Start only the first safe wave; inspect completed cards, resolve interfaces in the
+Sol primary, and then recalculate readiness and capacity before every later wave.
+
+Tell every worker it is not alone in the codebase, owns only its card, must preserve other
+edits, and must not spawn or delegate. Treat every report as a claim: inspect actual files,
+run the declared checks, and integrate only after the evidence is sufficient.
+
+## Portable-host route
+
+On a non-Codex host, first read `portable-hosts.md`; do not run Codex preflight scripts or
+claim fixed Luna/Terra routes. A concurrent first wave additionally requires observed model
+selection, separate worker contexts, reported actual/requested effort, host-advertised
+concurrency, and a separate fresh reviewer context. Record the actual provider/model/effort
+for every worker and do not rename requested values as observed ones.
+
+When independent cards and all non-concurrency capabilities are proven but the host cannot
+provide concurrent capacity, an explicitly selected Constellation may use the documented
+serial portable fallback. Keep the same cards, ownership, verification, and fresh reviewer;
+label the result serial and never call it concurrent or Guided-style routing. If separate
+worker or fresh reviewer context cannot be proven, stop.
+
+## Review and risk
+
+After integration and verification, start one new fresh exact Sol reviewer for the combined
+change set. Careful safeguards override Constellation whenever risk requires user
+confirmation, observed read-only reviewer isolation, or serial execution. A failed worker,
+failed check, or uncertain shared interface stops the affected route rather than expanding
+the Constellation.

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/modes-and-risk.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/modes-and-risk.md
@@ -11,11 +11,20 @@ confirmation or a fresh review.
 | Guided | Normal project work | Compact work card | Luna or Terra at configured effort | Fresh Sol review at configured effort after every worker-produced change |
 | Careful | Consequential or explicitly thorough work | Visible plan | Strict pinned implementation lanes at configured effort | Fresh Sol review at configured effort with observed read-only isolation |
 | Measured (explicit opt-in) | A deliberately slower, evidence-oriented route decision | One frozen work card and named checks | Sol selects one pinned worker; Luna/Terra probes only for routing ambiguity | Fresh Sol review; high-risk work also uses Careful safeguards |
+| Morph (explicit opt-in) | A bounded worker card that needs a user-selected routed model | Compact work card plus exact worker model and requested effort | Sol remains the configured primary; only the worker uses the explicit Morph route | Fresh exact Sol review at configured effort |
+| Constellation (explicit opt-in) | Several independently owned, ready cards | Sol proves independence and capacity before a concurrent first wave | Cost-aware non-Sol workers by default; capacity-limited fan-out | One fresh exact Sol review after integrated verification |
 
 Guided is the default. A user can simply say “Use Astral Orchestrator” without learning the
 mode system. Measured is never auto-selected: use it only when the user explicitly names
 it. It is intentionally slower and more model-intensive, so recommend Guided for normal
 work.
+Morph and Constellation are also explicit opt-in. They are never selected merely because another
+model is available or because concurrent work would be convenient. Read their dedicated
+references before using either mode.
+
+On a non-Codex host, Quick, Guided, Careful, and Measured retain their documented modes but do
+not acquire a generic replacement for their fixed Codex routes. Only explicitly selected Morph
+or Constellation may use portable-host rules, and only after those capabilities are observed.
 
 ## Risk levels
 
@@ -57,6 +66,9 @@ Typical signs:
 Use Careful even if the user asked for Quick. Explain that the risk raises the safeguards,
 not the scope. High-risk Measured work keeps its evidence-oriented routing and also
 inherits Careful confirmation and observed read-only isolation safeguards.
+Careful safeguards override Morph or Constellation whenever the work has this level of risk: keep
+the exact Sol primary and reviewer, use the required confirmation gates, and serialize any
+card whose safety, interface, or verification depends on another card.
 
 ## User confirmation gate
 
@@ -77,7 +89,7 @@ extra confirmation when they are already within the request.
 Fresh review means a separate agent context that did not implement the change and is
 instructed to remain behaviorally read-only.
 
-- Use the pinned Sol reviewer for Careful work and every Guided or Measured
+- Use the pinned Sol reviewer for Careful work and every Guided, Measured, Morph, or Constellation
   worker-produced change.
 - If the exact reviewer role, model, or effort cannot be proven, stop and report the
   independent review as incomplete. Do not silently substitute self-review.

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/morph-mode.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/morph-mode.md
@@ -1,0 +1,73 @@
+# Morph mode
+
+Morph is an explicit opt-in: use it only when the user explicitly names it. Morph keeps the configured
+`gpt-5.6-sol` Sol primary responsible for requirements, architecture, decomposition,
+integration, verification, and the final decision. The normal exact Sol reviewer remains
+required. Only a bounded worker card may use a user-selected model.
+
+## Codex route: before launch
+
+1. Complete the normal primary preflight and prove the configured Sol primary. Morph does
+   not enable a non-Sol primary or a non-Sol final reviewer.
+2. Record one private worker card with its exact ownership, exact `provider/model` or
+   native model identifier, and requested effort. Keep non-overlapping work serial unless
+   the user also explicitly selects Constellation.
+3. Resolve `../../scripts/run-morph-agent.py`, write the card to a private regular file,
+   and require a successful dry run:
+
+   ```text
+   python3 run-morph-agent.py --model <provider/model> --effort <label> \
+     --workdir <workspace> --prompt-file <private-card> --dry-run
+   ```
+
+4. Start the same command without `--dry-run` only after the card is ready. It launches
+   `codex exec` with the exact worker model, requested effort, and workspace-write
+   sandbox. Capture its `ASTRAL_ORCHESTRATOR_ROUTE` evidence, process identity, exit
+   status, and actual result. A launch or runtime failure blocks that worker; do not
+   substitute a different worker silently.
+5. After the process exits, including a non-zero exit, remove only that exact private
+   packet. Do not use a broad or recursive deletion, and do not remove any other packet
+   or user file.
+
+The evidence labels the requested effort separately from upstream-native effort. An
+accepted label is **requested-only** and does not verify upstream-native effort semantics.
+Depending on the configured provider and model, effort can be native, mapped, clamped,
+emulated, or absent. Do not call it native unless independent upstream evidence proves
+that fact.
+
+## OpenCodex boundary
+
+OpenCodex is optional and independently installed and configured by the user. Astral
+never modifies ~/.opencodex, starts services, installs packages, handles provider
+credentials, or assumes provider terms-of-service compatibility. It adds no network
+dependency: the launcher invokes only the user’s existing `codex` command.
+
+Provider/model support and effort semantics are capability-dependent. A user must wire an
+OpenCodex provider route to Codex separately before Morph can use it. If the provider,
+model, requested effort, or process route fails at runtime, stop that worker and report
+the smallest corrective action; do not claim that Morph completed.
+
+A user-configured external or non-OpenAI provider can receive the worker packet as part of
+model inference. “No network dependency” means Astral adds no network client, service, or
+credential handling; it does not mean provider traffic or model inference is local.
+
+## Portable-host route
+
+On a non-Codex host, first read `portable-hosts.md`. Do not run `run-morph-agent.py`,
+`check-primary.py`, or use a Codex agent name. The host must expose an observed separate
+worker context, actual provider/model selection, and a separate fresh reviewer context.
+Record actual and requested provider, model, and effort separately. A requested effort is
+not evidence that the provider accepted or natively supported it.
+
+Give the external or non-OpenAI worker only its bounded private packet; it must perform the
+card directly and must not spawn or delegate. It may receive the packet as part of provider
+inference, so say that plainly. After the worker exits, including a failure, remove only that
+exact private packet with a narrow host operation. If any required capability is absent or
+unobservable, stop rather than attempting a Codex fallback or claiming a fixed Astral lane.
+
+## Review and risk
+
+After a Morph worker changes anything, Sol integrates and verifies the actual change set,
+then starts a new exact fresh Sol reviewer using the normal route. Careful safeguards
+override Morph whenever risk requires confirmation, observed read-only review isolation,
+or serial routing. Morph never changes those requirements.

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/portable-hosts.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/portable-hosts.md
@@ -1,0 +1,49 @@
+# Portable-host routes
+
+Use this reference only after the core skill has established that the host is not Codex
+and the user explicitly selected Morph or Constellation. The package format can make the
+skill discoverable; it does not provide an orchestration runtime.
+
+## Capability record
+
+Before starting a portable worker, record the host name/version when exposed and observable evidence
+for each required capability. Do not infer a capability from the host’s name or from a
+plugin-install success.
+
+| Capability | Required for |
+| --- | --- |
+| Select and report an actual provider/model | Morph and Constellation |
+| Separate worker context | Morph and Constellation |
+| Requested and actual effort reporting, when effort is offered | Morph and Constellation |
+| New reviewer context distinct from primary and workers | Morph and Constellation |
+| Available worker concurrency | Concurrent Constellation only |
+
+For every route record: host, requested provider/model/effort, actual provider/model/effort,
+whether each value is observed or merely requested, worker-context identity, reviewer-context
+identity, and the checks run. Never relabel an unknown actual value as a configured value.
+
+## Portable Morph
+
+Require a bounded, non-overlapping worker card and an observed separate worker context.
+Pass only that card through the host’s documented worker mechanism. A user-configured
+external provider can receive that packet; say so plainly, never handle credentials, and
+use no recursive delegation. After the worker returns, remove only that exact private
+packet through the host’s safe narrow operation. If actual provider/model, requested
+effort handling, or fresh reviewer context cannot be observed, stop and report the
+missing capability.
+
+## Portable Constellation
+
+Start concurrent workers only when independent ownership, all worker contexts, host
+capacity, and a fresh reviewer context are observed. Reserve and count the primary as one
+occupied slot before calculating worker capacity, regardless of whether the host advertises
+it. If concurrency is unavailable but the worker and reviewer requirements are proven, an
+explicitly selected Constellation may run the same cards serially, clearly labeled **serial
+portable fallback**. Do not call it Guided, do not claim it was concurrent, and do not run
+more workers merely to fill capacity.
+
+## Fresh review
+
+Integrate and verify actual changes before review. A reviewer is fresh only when the host
+provides a context separate from the primary and every worker. If that cannot be observed,
+do not substitute a primary self-review and do not claim independent review.

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
@@ -1,7 +1,9 @@
 # Routing and preflight
 
-Use this reference for every Guided, Careful, or Measured run. The purpose is to prove that work
-used the intended lanes, not merely to request them.
+Use this reference for every Codex run that needs primary-route proof. The purpose is to prove
+that work used the intended lanes, not merely to request them. Morph and Constellation add worker
+rules only when the user explicitly selects those modes; they do not alter this primary,
+fixed-route, or reviewer contract.
 
 ## Exact route contract
 
@@ -26,10 +28,16 @@ Never silently downgrade a value that Codex rejects.
 Before execution in any mode:
 
 1. Resolve `../../scripts/configure-effort.py` relative to this skill and run
-   `python3 configure-effort.py --show --json`. Confirm the configured orchestrator effort
-   matches observable runtime evidence for the `gpt-5.6-sol` primary model. If the host
-   exposes no primary metadata, obtain one explicit
-   user confirmation and label it user-supplied rather than observed.
+   `python3 configure-effort.py --show --json`. Then resolve
+   `../../scripts/check-primary.py` and run it before the one-time confirmation fallback.
+   Its optional `--thread-id` defaults to `CODEX_THREAD_ID`; use `--sessions-dir` only for
+   local test evidence. It invokes the bundled runtime inspector rather than reading
+   rollout content itself, emits allowlisted JSON, and exits zero only when the observed
+   primary model is `gpt-5.6-sol` and its effort equals the configured orchestrator effort.
+   When its status is `unavailable`, obtain one explicit user confirmation and label it
+   user-supplied rather than observed. When status is `mismatch`, stop and correct the
+   route; do not ask a user to waive a mismatch. `invalid` means malformed, ambiguous, or
+   rejected local evidence and also blocks the route; manual confirmation cannot waive it.
 2. Read applicable workspace instructions and inspect the current change state.
 3. Define the work card and identify whether worker cards can have non-overlapping
    ownership.
@@ -59,6 +67,12 @@ Measured uses this same exact route contract and preflight. Its frozen-card stat
 resumption question, behavioral planning probes, deterministic selection rules, and
 ledger are defined in `measured-mode.md`; those details never alter the configured model
 or effort for a lane.
+
+Morph and Constellation use this same exact Sol primary preflight. Read `morph-mode.md` or
+`constellation-mode.md` only after the user explicitly opts in. Morph workers use
+`run-morph-agent.py` rather than changing the fixed Luna/Terra contracts. Constellation may use
+the normal fixed worker routes or explicit Morph cards, but never changes the Sol primary
+or fresh Sol reviewer.
 
 ## Lane decision
 

--- a/release/astral-release-ledger.json
+++ b/release/astral-release-ledger.json
@@ -86,6 +86,14 @@
       "evidence": "Production deployment dpl_7u8PBDrvsJmD2urm9wfMcapr1VoR reached READY and the alias served the 109-test copy, 1,940-token static measurement, and no-valid-outcome-comparison disclosure; verified in Opera GX.",
       "url": "https://astral-orchestrator.vercel.app/",
       "commit": "abce4182a13c212d1012d76795649a81c9ef5f59"
+    },
+    {
+      "surface": "openai_directory",
+      "version": "3.2.0",
+      "status": "published",
+      "observed_at": "2026-08-09T19:43:36+08:00",
+      "evidence": "OpenAI Platform plugin management in Opera GX displayed Astral Orchestrator version 3.2.0 with status Published and View in Directory on 2026-08-09.",
+      "url": "https://chatgpt.com/plugins/plugins_6a702dc6da648191a24bb8b82093f3cc"
     }
   ]
 }

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -2,6 +2,7 @@ import importlib.util
 import hashlib
 import io
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -23,17 +24,23 @@ NOTICE = ROOT / "NOTICE.md"
 PLUGIN_LICENSE = PLUGIN / "LICENSE"
 PLUGIN_NOTICE = PLUGIN / "NOTICE.md"
 MANIFEST = PLUGIN / ".codex-plugin/plugin.json"
+PORTABLE_MANIFEST = PLUGIN / "plugin.json"
+PORTABILITY = ROOT / "docs/PORTABILITY.md"
 OPENAI_METADATA = PLUGIN / "skills/astral-orchestrator/agents/openai.yaml"
 BANNER = ROOT / "assets/brand/astral-orchestrator-banner.gif"
 SKILL = PLUGIN / "skills/astral-orchestrator/SKILL.md"
 MODES = PLUGIN / "skills/astral-orchestrator/references/modes-and-risk.md"
 TEMPLATES = PLUGIN / "skills/astral-orchestrator/references/work-templates.md"
 ROUTING = PLUGIN / "skills/astral-orchestrator/references/routing-and-preflight.md"
+MORPH = PLUGIN / "skills/astral-orchestrator/references/morph-mode.md"
+CONSTELLATION = PLUGIN / "skills/astral-orchestrator/references/constellation-mode.md"
 MEASURED = PLUGIN / "skills/astral-orchestrator/references/measured-mode.md"
 AGENTS = PLUGIN / "agents"
 INSTALL_AGENTS = PLUGIN / "scripts/install-agents.sh"
 INSPECT_RUNTIME = PLUGIN / "scripts/inspect-agent-runtime.sh"
+CHECK_PRIMARY = PLUGIN / "scripts/check-primary.py"
 RUN_AGENT = PLUGIN / "scripts/run-agent.py"
+RUN_MORPH_AGENT = PLUGIN / "scripts/run-morph-agent.py"
 CONFIGURE_EFFORT = PLUGIN / "scripts/configure-effort.py"
 EFFORT_SETTINGS = PLUGIN / "scripts/effort_settings.py"
 CONFIGURE_EFFORT_WRAPPER = ROOT / "scripts/configure-effort.sh"
@@ -89,7 +96,7 @@ class MarketplaceTests(unittest.TestCase):
         manifest = load_json(MANIFEST)
 
         self.assertEqual(manifest["name"], "astral-orchestrator")
-        self.assertEqual(manifest["version"], "3.2.0")
+        self.assertEqual(manifest["version"], "3.3.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertEqual(manifest["skills"], "./skills/")
         self.assertEqual(manifest["interface"]["displayName"], "Astral Orchestrator")
@@ -105,13 +112,13 @@ class MarketplaceTests(unittest.TestCase):
         self.assertNotIn("mcpServers", manifest)
         self.assertNotIn("apps", manifest)
         self.assertNotIn("hooks", manifest)
-        self.assertTrue(read(SPEC).startswith("# Spec: Astral Orchestrator v3.2"))
+        self.assertTrue(read(SPEC).startswith("# Spec: Astral Orchestrator v3.3"))
 
         interface = manifest["interface"]
         self.assertEqual(interface["composerIcon"], "./skills/astral-orchestrator/assets/icon.png")
         self.assertEqual(interface["logo"], "./skills/astral-orchestrator/assets/icon.png")
         description = interface["longDescription"].lower()
-        for mode in ("quick", "guided", "careful", "measured"):
+        for mode in ("quick", "guided", "careful", "measured", "morph", "constellation"):
             self.assertIn(mode, description)
         self.assertIn("opt-in", description)
         self.assertIn("never runs automatically", description)
@@ -121,9 +128,87 @@ class MarketplaceTests(unittest.TestCase):
         self.assertGreaterEqual(len(prompts), 2)
         self.assertLessEqual(len(prompts), 3)
         self.assertTrue(all(len(prompt) <= 128 for prompt in prompts))
-        self.assertTrue(any("measured mode" in prompt.lower() for prompt in prompts))
+        prompt_text = " ".join(prompts).lower()
+        for mode in ("quick", "guided", "careful", "measured", "morph", "constellation"):
+            self.assertIn(mode, prompt_text)
 
-    def test_openai_metadata_keeps_shared_icon_and_measured_aware_prompt(self):
+    def test_portable_manifest_uses_agent_plugins_v1_fixed_skill_discovery(self):
+        manifest = load_json(PORTABLE_MANIFEST)
+
+        self.assertEqual(
+            manifest["$schema"],
+            "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        )
+        self.assertEqual(manifest["name"], "astral-orchestrator")
+        self.assertEqual(manifest["version"], "3.3.0")
+        self.assertEqual(manifest["license"], "MIT")
+        self.assertEqual(
+            set(manifest),
+            {
+                "$schema",
+                "name",
+                "version",
+                "description",
+                "author",
+                "homepage",
+                "repository",
+                "license",
+                "keywords",
+            },
+        )
+        self.assertNotIn("skills", manifest)
+        self.assertNotIn("interface", manifest)
+
+        plugin_root = PLUGIN.resolve()
+        discovered = PLUGIN / "skills/astral-orchestrator/SKILL.md"
+        self.assertTrue(discovered.is_file())
+        self.assertEqual(discovered.resolve().parents[2], plugin_root)
+
+    def test_portability_docs_limit_non_codex_routes_to_observed_capabilities(self):
+        portability = " ".join(read(PORTABILITY).lower().split())
+        skill = " ".join(read(SKILL).lower().split())
+        portable_hosts = " ".join(read(PLUGIN / "skills/astral-orchestrator/references/portable-hosts.md").lower().split())
+        readme = read(ROOT / "README.md").lower()
+
+        for required in (
+            "skills and mcp discovery only",
+            "not agents, concurrency, model selection, or reasoning effort",
+            "vs code",
+            "cursor",
+            "github copilot",
+            "chatgpt/codex",
+            "kiro",
+            "component types incrementally",
+            "https://agent-plugins.org/specification",
+            "https://agent-plugins.org/compatible-clients",
+        ):
+            self.assertIn(required, portability)
+        for required in (
+            "whether the host is codex",
+            "portable-hosts.md",
+            "observable host capabilities",
+            "never claim sol/luna/terra unless observed",
+        ):
+            self.assertIn(required, skill)
+        self.assertIn("reserve and count the primary as one occupied slot", portable_hosts)
+        self.assertIn("regardless of whether the host advertises it", portable_hosts)
+        for forbidden in (
+            "agent plugins",
+            "agent-plugins.org",
+            "portable manifest",
+            "compatible clients",
+            "cross-client",
+        ):
+            self.assertNotIn(forbidden, readme)
+
+    def test_readme_safety_qualifies_external_morph_packet_processing(self):
+        readme = " ".join(read(ROOT / "README.md").lower().split())
+
+        self.assertIn("fixed local codex routes", readme)
+        self.assertIn("external morph provider can receive its bounded worker packet", readme)
+        self.assertNotIn("work packets remain local", readme)
+
+    def test_openai_metadata_keeps_shared_icon_and_six_mode_aware_prompt(self):
         metadata = read(OPENAI_METADATA)
 
         self.assertIn('icon_small: "./assets/icon.png"', metadata)
@@ -133,19 +218,52 @@ class MarketplaceTests(unittest.TestCase):
         )
         prompt = prompt_line.split(":", 1)[1].strip().strip('"')
         self.assertLessEqual(len(prompt), 128)
-        self.assertIn("guided mode", prompt.lower())
-        self.assertIn("measured mode", prompt.lower())
+        for mode in ("guided", "quick", "careful", "measured", "morph", "constellation"):
+            self.assertIn(mode, prompt.lower())
 
 
 class SkillContractTests(unittest.TestCase):
-    def test_skill_uses_four_plain_language_modes(self):
+    def test_skill_uses_six_plain_language_modes_and_loads_opt_in_references_on_demand(self):
         skill = read(SKILL)
         modes = read(MODES)
 
-        for mode in ("Quick", "Guided", "Careful", "Measured"):
+        for mode in ("Quick", "Guided", "Careful", "Measured", "Morph", "Constellation"):
             self.assertIn(mode, skill)
             self.assertIn(mode, modes)
         self.assertRegex(skill, r"Guided[^\n]*(default|Default)")
+        self.assertIn("when the user explicitly names morph", skill.lower())
+        self.assertIn("when the user explicitly names constellation", skill.lower())
+        self.assertTrue(MORPH.is_file())
+        self.assertTrue(CONSTELLATION.is_file())
+
+        morph = " ".join(read(MORPH).lower().split())
+        constellation = read(CONSTELLATION).lower()
+        for required in (
+            "explicit opt-in",
+            "opencodex is optional",
+            "never modifies ~/.opencodex",
+            "provider/model",
+            "requested effort",
+            "upstream-native effort",
+            "fresh sol reviewer",
+            "after the process exits",
+            "remove only that exact private packet",
+            "external or non-openai provider",
+            "worker packet as part of",
+            "does not mean provider traffic or model inference is local",
+        ):
+            self.assertIn(required, morph)
+        for required in (
+            "explicit opt-in",
+            "first wave concurrently",
+            "available slots",
+            "primary consumes one slot",
+            "non-overlapping",
+            "serial guided-style routing",
+            "do not spawn extra sol implementers",
+            "fresh sol reviewer",
+        ):
+            self.assertIn(required, constellation)
 
     def test_measured_state_sequence_templates_and_safe_state_are_explicit(self):
         measured = " ".join(read(MEASURED).lower().split())
@@ -368,6 +486,18 @@ class SkillContractTests(unittest.TestCase):
                         ),
                         json.dumps(
                             {
+                                "type": "session_meta",
+                                "payload": {
+                                    "id": thread_id,
+                                    "parent_thread_id": "parent",
+                                    "agent_nickname": "Atlas",
+                                    "agent_path": "/profiles/astral-orchestrator-luna-implementer.toml",
+                                    "model_provider": "openai",
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
                                 "type": "turn_context",
                                 "payload": {
                                     "model": "gpt-5.6-luna",
@@ -410,6 +540,30 @@ class SkillContractTests(unittest.TestCase):
             self.assertNotIn("agent_role", evidence)
             self.assertNotIn("secret", evidence)
             self.assertNotIn("prompt", evidence)
+
+            rollout.write_text(
+                rollout.read_text(encoding="utf-8").replace(
+                    '"agent_nickname": "Atlas"',
+                    '"agent_nickname": "Conflict"',
+                    1,
+                ),
+                encoding="utf-8",
+            )
+            conflicting = subprocess.run(
+                [
+                    "sh",
+                    str(INSPECT_RUNTIME),
+                    "--sessions-dir",
+                    str(sessions),
+                    thread_id,
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(conflicting.returncode, 0)
+            self.assertIn("ambiguous", conflicting.stderr)
 
     def test_runtime_inspector_resolves_the_task_path_returned_by_spawn(self):
         thread_id = "87654321-4321-4321-4321-cba987654321"
@@ -470,6 +624,445 @@ class SkillContractTests(unittest.TestCase):
             self.assertEqual(evidence["thread_id"], thread_id)
             self.assertEqual(evidence["agent_path"], agent_path)
             self.assertEqual(evidence["model"], "gpt-5.6-luna")
+
+    def test_primary_checker_uses_the_bundled_inspector_and_never_leaks_rollout_contents(self):
+        thread_id = "12345678-1234-1234-1234-123456789abc"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sessions = root / "sessions"
+            sessions.mkdir()
+            rollout = sessions / f"rollout-primary-{thread_id}.jsonl"
+            rollout.write_text(
+                "\n".join(
+                    (
+                        json.dumps(
+                            {
+                                "type": "session_meta",
+                                "payload": {
+                                    "id": thread_id,
+                                    "model_provider": "openai",
+                                    "secret": "must-not-leak",
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "turn_context",
+                                "payload": {
+                                    "model": "gpt-5.6-sol",
+                                    "effort": "high",
+                                    "sandbox_policy": {"type": "workspace-write"},
+                                    "permission_profile": {"type": "managed"},
+                                    "cwd": str(ROOT),
+                                    "prompt": "must-not-leak",
+                                },
+                            }
+                        ),
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            matched = subprocess.run(
+                [
+                    "python3",
+                    str(CHECK_PRIMARY),
+                    "--thread-id",
+                    thread_id,
+                    "--sessions-dir",
+                    str(sessions),
+                    "--settings-file",
+                    str(root / "missing-effort-levels.toml"),
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(matched.returncode, 0, matched.stdout + matched.stderr)
+            evidence = json.loads(matched.stdout)
+            self.assertEqual(evidence["status"], "match")
+            self.assertEqual(evidence["expected_model"], "gpt-5.6-sol")
+            self.assertEqual(evidence["expected_effort"], "high")
+            self.assertEqual(evidence["observed_model"], "gpt-5.6-sol")
+            self.assertEqual(evidence["observed_effort"], "high")
+            self.assertEqual(evidence["thread_id"], thread_id)
+            self.assertNotIn("secret", matched.stdout)
+            self.assertNotIn("prompt", matched.stdout)
+
+            rollout.write_text(
+                rollout.read_text(encoding="utf-8").replace('"high"', '"low"'),
+                encoding="utf-8",
+            )
+            mismatched = subprocess.run(
+                [
+                    "python3",
+                    str(CHECK_PRIMARY),
+                    "--thread-id",
+                    thread_id,
+                    "--sessions-dir",
+                    str(sessions),
+                    "--settings-file",
+                    str(root / "missing-effort-levels.toml"),
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(mismatched.returncode, 0)
+            self.assertEqual(json.loads(mismatched.stdout)["status"], "mismatch")
+
+            unavailable = subprocess.run(
+                [
+                    "python3",
+                    str(CHECK_PRIMARY),
+                    "--settings-file",
+                    str(root / "missing-effort-levels.toml"),
+                ],
+                cwd=ROOT,
+                env={key: value for key, value in os.environ.items() if key != "CODEX_THREAD_ID"},
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(unavailable.returncode, 0)
+            self.assertEqual(json.loads(unavailable.stdout)["status"], "unavailable")
+
+    def test_primary_checker_fails_closed_for_invalid_evidence_and_settings(self):
+        thread_id = "abcdefab-cdef-cdef-cdef-abcdefabcdef"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sessions = root / "sessions"
+            sessions.mkdir()
+            rollout = sessions / f"rollout-primary-{thread_id}.jsonl"
+            rollout.write_text(
+                "\n".join(
+                    (
+                        json.dumps(
+                            {
+                                "type": "session_meta",
+                                "payload": {
+                                    "id": thread_id,
+                                    "agent_nickname": "Primary",
+                                    "secret": "must-not-leak",
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "session_meta",
+                                "payload": {
+                                    "id": thread_id,
+                                    "agent_nickname": "Conflicting metadata",
+                                },
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "type": "turn_context",
+                                "payload": {
+                                    "model": "gpt-5.6-sol",
+                                    "effort": "high",
+                                    "sandbox_policy": {"type": "workspace-write"},
+                                    "permission_profile": {"type": "managed"},
+                                    "cwd": str(ROOT),
+                                    "prompt": "must-not-leak",
+                                },
+                            }
+                        ),
+                    )
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            def check(settings: Path) -> subprocess.CompletedProcess[str]:
+                return subprocess.run(
+                    [
+                        "python3",
+                        str(CHECK_PRIMARY),
+                        "--thread-id",
+                        thread_id,
+                        "--sessions-dir",
+                        str(sessions),
+                        "--settings-file",
+                        str(settings),
+                    ],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+
+            conflicting = check(root / "missing-effort-levels.toml")
+            self.assertNotEqual(conflicting.returncode, 0)
+            conflicting_evidence = json.loads(conflicting.stdout)
+            self.assertEqual(conflicting_evidence["status"], "invalid")
+            self.assertNotIn("secret", conflicting.stdout)
+            self.assertNotIn("prompt", conflicting.stdout)
+            self.assertLessEqual(
+                set(conflicting_evidence),
+                {
+                    "expected_effort",
+                    "expected_model",
+                    "observed_effort",
+                    "observed_model",
+                    "reason",
+                    "status",
+                    "thread_id",
+                },
+            )
+
+            duplicate_filename = sessions / f"rollout-copy-{thread_id}.jsonl"
+            duplicate_filename.write_bytes(rollout.read_bytes())
+            ambiguous = check(root / "missing-effort-levels.toml")
+            self.assertNotEqual(ambiguous.returncode, 0)
+            self.assertEqual(json.loads(ambiguous.stdout)["status"], "invalid")
+            duplicate_filename.unlink()
+
+            malformed_settings = root / "effort-levels.toml"
+            malformed_settings.write_text("[effort\norchestrator = \"high\"\n", encoding="utf-8")
+            malformed = check(malformed_settings)
+            self.assertNotEqual(malformed.returncode, 0)
+            self.assertEqual(json.loads(malformed.stdout)["status"], "invalid")
+
+            rollout.unlink()
+            missing_rollout = check(root / "missing-effort-levels.toml")
+            self.assertNotEqual(missing_rollout.returncode, 0)
+            self.assertEqual(json.loads(missing_rollout.stdout)["status"], "unavailable")
+
+    def test_primary_checker_marks_malformed_or_invalid_inspector_evidence_invalid(self):
+        spec = importlib.util.spec_from_file_location(
+            "astral_orchestrator_check_primary", CHECK_PRIMARY
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(checker)
+
+        thread_id = "12345678-1234-1234-1234-123456789abc"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            rollout = root / f"rollout-primary-{thread_id}.jsonl"
+            rollout.write_text("{}\n", encoding="utf-8")
+
+            for stdout in (
+                "not-json",
+                json.dumps([]),
+                json.dumps(
+                    {
+                        "thread_id": thread_id,
+                        "model": "invalid model id",
+                        "effort": "high",
+                    }
+                ),
+            ):
+                output = io.StringIO()
+                with (
+                    mock.patch.object(
+                        sys,
+                        "argv",
+                        [
+                            str(CHECK_PRIMARY),
+                            "--thread-id",
+                            thread_id,
+                            "--settings-file",
+                            str(root / "missing-effort-levels.toml"),
+                        ],
+                    ),
+                    mock.patch.object(checker, "find_rollouts", return_value=[rollout]),
+                    mock.patch.object(
+                        checker.subprocess,
+                        "run",
+                        return_value=subprocess.CompletedProcess([], 0, stdout, ""),
+                    ),
+                    redirect_stdout(output),
+                ):
+                    self.assertEqual(checker.main(), 1)
+                evidence = json.loads(output.getvalue())
+                self.assertEqual(evidence["status"], "invalid")
+                self.assertEqual(evidence["reason"], "runtime-evidence-invalid")
+
+    def test_primary_checker_distinguishes_missing_from_malformed_thread_ids(self):
+        spec = importlib.util.spec_from_file_location(
+            "astral_orchestrator_check_primary_thread_id", CHECK_PRIMARY
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        checker = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(checker)
+
+        with tempfile.TemporaryDirectory() as directory:
+            settings = Path(directory) / "missing-effort-levels.toml"
+
+            def invoke(arguments: list[str], environment: dict[str, str]):
+                output = io.StringIO()
+                with (
+                    mock.patch.object(sys, "argv", [str(CHECK_PRIMARY), *arguments]),
+                    mock.patch.dict(os.environ, environment, clear=True),
+                    redirect_stdout(output),
+                ):
+                    self.assertEqual(checker.main(), 1)
+                return json.loads(output.getvalue())
+
+            missing = invoke(["--settings-file", str(settings)], {})
+            malformed_environment = invoke(
+                ["--settings-file", str(settings)],
+                {"CODEX_THREAD_ID": "not-a-uuid"},
+            )
+            malformed_argument = invoke(
+                [
+                    "--thread-id",
+                    "also-not-a-uuid",
+                    "--settings-file",
+                    str(settings),
+                ],
+                {},
+            )
+
+        self.assertEqual(
+            (missing["status"], missing["reason"]),
+            ("unavailable", "thread-id-unavailable"),
+        )
+        self.assertEqual(
+            (malformed_environment["status"], malformed_environment["reason"]),
+            ("invalid", "thread-id-invalid"),
+        )
+        self.assertEqual(
+            (malformed_argument["status"], malformed_argument["reason"]),
+            ("invalid", "thread-id-invalid"),
+        )
+
+    def test_morph_launcher_validates_private_packets_and_marks_effort_as_requested_only(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            prompt.write_text("private Morph work card\n", encoding="utf-8")
+            prompt.chmod(0o600)
+
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(RUN_MORPH_AGENT),
+                    "--model",
+                    "opencodex/worker-model",
+                    "--effort",
+                    "xhigh",
+                    "--workdir",
+                    str(workdir),
+                    "--prompt-file",
+                    str(prompt),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            evidence = json.loads(result.stdout)
+            self.assertEqual(evidence["route"], "morph")
+            self.assertEqual(evidence["model"], "opencodex/worker-model")
+            self.assertEqual(evidence["requested_effort"], "xhigh")
+            self.assertEqual(evidence["verified_upstream_native_effort"], "unverified")
+            self.assertEqual(evidence["effort_semantics"], "requested-only")
+            self.assertEqual(evidence["sandbox"], "workspace-write")
+            self.assertNotIn("private Morph work card", result.stdout)
+
+            invalid_model = subprocess.run(
+                [
+                    "python3",
+                    str(RUN_MORPH_AGENT),
+                    "--model",
+                    "bad model id",
+                    "--effort",
+                    "high",
+                    "--workdir",
+                    str(workdir),
+                    "--prompt-file",
+                    str(prompt),
+                    "--dry-run",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(invalid_model.returncode, 0)
+            self.assertIn("model", invalid_model.stderr.lower())
+
+    def test_morph_launcher_constructs_the_explicit_workspace_write_codex_route(self):
+        spec = importlib.util.spec_from_file_location(
+            "astral_orchestrator_run_morph_agent", RUN_MORPH_AGENT
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        launcher = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(launcher)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            prompt_text = "private Morph card\n"
+            prompt.write_text(prompt_text, encoding="utf-8")
+            prompt.chmod(0o600)
+            captured = {}
+
+            def fake_run(command, *, input, check):
+                captured["command"] = command
+                captured["input"] = input
+                captured["check"] = check
+                return subprocess.CompletedProcess(command, 17)
+
+            output = io.StringIO()
+            argv = [
+                str(RUN_MORPH_AGENT),
+                "--model",
+                "opencodex/worker-model",
+                "--effort",
+                "medium",
+                "--workdir",
+                str(workdir),
+                "--prompt-file",
+                str(prompt),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(launcher.shutil, "which", return_value="/test/codex"),
+                mock.patch.object(launcher.subprocess, "run", side_effect=fake_run),
+                redirect_stdout(output),
+            ):
+                return_code = launcher.main()
+
+            command = captured["command"]
+            config_overrides = [
+                command[index + 1]
+                for index, value in enumerate(command)
+                if value == "-c"
+            ]
+            self.assertEqual(return_code, 17)
+            self.assertEqual(captured["input"], prompt_text.encode())
+            self.assertFalse(captured["check"])
+            self.assertEqual(command[:2], ["/test/codex", "exec"])
+            self.assertEqual(command[command.index("--model") + 1], "opencodex/worker-model")
+            self.assertEqual(command[command.index("--sandbox") + 1], "workspace-write")
+            self.assertEqual(command[command.index("--cd") + 1], str(workdir.resolve()))
+            self.assertEqual(command[-1], "-")
+            self.assertIn('model_reasoning_effort="medium"', config_overrides)
+            self.assertIn(
+                f"developer_instructions={json.dumps(launcher.MORPH_DEVELOPER_INSTRUCTIONS)}",
+                config_overrides,
+            )
+            self.assertIn("must not spawn or delegate", launcher.MORPH_DEVELOPER_INSTRUCTIONS)
+            route_header = output.getvalue()
+            self.assertIn("ASTRAL_ORCHESTRATOR_ROUTE ", route_header)
+            self.assertNotIn(prompt_text.strip(), route_header)
 
     def test_process_launcher_maps_every_role_to_exact_runtime_settings(self):
         expected = {
@@ -1052,7 +1645,7 @@ class UserExperienceTests(unittest.TestCase):
             .split("## Configurable effort levels", 1)[0]
             .split()
         )
-        self.assertIn("published v3.2.0 core `SKILL.md` measures **2,036 tokens**", footprint)
+        self.assertIn("historical v3.2.0 core `SKILL.md` measures **2,036 tokens**", footprint)
         self.assertIn("Guided/full measures **5,636 tokens**", footprint)
         self.assertIn("Measured measures **7,795 tokens**", footprint)
         self.assertIn("instruction-context loading only", footprint)
@@ -1066,8 +1659,8 @@ class UserExperienceTests(unittest.TestCase):
         self.assertIn("inspired by", attribution)
         self.assertIn("pinned codex gpt-5.6 sol/terra/luna lanes", attribution)
         self.assertIn("does not run or depend on ori or openrouter", attribution)
-        self.assertIn("worker-produced guided or measured work", attribution)
-        self.assertIn("guided, careful, and measured require all three", attribution)
+        self.assertIn("worker-produced guided, measured, morph, or constellation work", attribution)
+        self.assertIn("guided, careful, and measured require the three", attribution)
 
     def test_editable_diagrams_preserve_rendered_labels_and_quick_handoff(self):
         namespace = {"svg": "http://www.w3.org/2000/svg"}
@@ -1104,7 +1697,7 @@ class UserExperienceTests(unittest.TestCase):
             )
             self.assertEqual(source_text, svg_text, source.name)
 
-    def test_context_footprint_evidence_matches_the_published_instruction_files(self):
+    def test_context_footprint_evidence_is_a_valid_historical_snapshot(self):
         self.assertTrue(CONTEXT_FOOTPRINT.is_file())
         evidence = load_json(CONTEXT_FOOTPRINT_MEASURED)
         self.assertTrue(CONTEXT_FOOTPRINT_MEASURER.is_file())
@@ -1114,17 +1707,21 @@ class UserExperienceTests(unittest.TestCase):
             {"library": "tiktoken", "version": "0.13.0", "encoding": "o200k_base"},
         )
 
-        expected = {
-            item["path"]: (item["bytes"], item["words"], item["tokens"])
-            for item in evidence["files"]
-        }
-        self.assertEqual({item["path"] for item in evidence["files"]}, set(expected))
+        expected_paths = {item["path"] for item in evidence["files"]}
+        self.assertEqual(len(expected_paths), len(evidence["files"]))
         for item in evidence["files"]:
-            path = ROOT / item["path"]
-            data = path.read_bytes()
-            self.assertEqual(
-                (item["bytes"], item["words"], item["tokens"]), expected[item["path"]]
+            snapshot = subprocess.run(
+                ["git", "show", f"v3.2.0:{item['path']}"],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
             )
+            if snapshot.returncode != 0:
+                self.fail(
+                    "historical instruction snapshot v3.2.0 is unavailable for "
+                    f"{item['path']}: {snapshot.stderr.decode('utf-8', 'replace')}"
+                )
+            data = snapshot.stdout
             self.assertEqual(item["bytes"], len(data))
             self.assertEqual(item["words"], len(data.decode("utf-8").split()))
             self.assertEqual(item["sha256"], hashlib.sha256(data).hexdigest())
@@ -1158,7 +1755,7 @@ class UserExperienceTests(unittest.TestCase):
             .split("## Configurable effort levels", 1)[0]
             .split()
         )
-        self.assertIn("published v3.2.0 core", footprint_section)
+        self.assertIn("historical v3.2.0 core", footprint_section)
         for value in (
             evidence["bundles"]["core"]["tokens"],
             evidence["bundles"]["quick"]["tokens"],
@@ -1693,7 +2290,7 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
             "--ledger",
             str(RELEASE_LEDGER),
             "--expected-version",
-            "3.2.0",
+            "3.3.0",
             "--format",
             "json",
         )
@@ -1704,7 +2301,7 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
         self.assertEqual(surfaces["github_release"]["version"], "3.2.0")
         self.assertEqual(surfaces["vercel"]["status"], "deployed")
         self.assertEqual(surfaces["openai_submission"]["status"], "draft")
-        self.assertEqual(surfaces["openai_directory"]["version"], "3.1.3")
+        self.assertEqual(surfaces["openai_directory"]["version"], "3.2.0")
 
     def test_strict_release_check_fails_while_public_directory_lags(self):
         result = self.run_ledger(
@@ -1712,13 +2309,13 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
             "--ledger",
             str(RELEASE_LEDGER),
             "--expected-version",
-            "3.2.0",
+            "3.3.0",
             "--manifest",
             str(MANIFEST),
         )
 
         self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-        self.assertIn("openai_directory is 3.1.3", result.stderr)
+        self.assertIn("openai_directory is 3.2.0", result.stderr)
 
     def test_record_is_idempotent_and_preserves_history(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -1850,6 +2447,30 @@ class VerificationTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("canonical NOTICE must link", result.stderr)
+
+    def test_repository_verifier_rejects_a_portable_discovered_skill_symlink_escape(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = self.make_package_fixture(directory)
+            fixture_plugin = fixture_root / "plugins/astral-orchestrator"
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            escaped_skill = outside / "SKILL.md"
+            escaped_skill.write_text("---\nname: escaped\n---\n", encoding="utf-8")
+
+            discovered = fixture_plugin / "skills/astral-orchestrator/SKILL.md"
+            discovered.unlink()
+            discovered.symlink_to(escaped_skill)
+
+            result = subprocess.run(
+                ["sh", str(fixture_plugin / "scripts/verify.sh")],
+                cwd=fixture_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("portable discovered skill escapes the package", result.stderr)
 
     def test_repository_verifier_passes(self):
         verifier = PLUGIN / "scripts/verify.sh"

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -300,6 +300,60 @@ class WebsiteContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, home)
 
+    def test_homepage_presents_exactly_six_modes(self):
+        home = page_text(PAGES["home"])
+        self.assertIn("Six modes", home)
+        self.assertEqual(
+            len(re.findall(r'<article class="mode-card(?: [^"]+)?"', home)),
+            6,
+        )
+        expected_tags = {
+            "quick": "Quick",
+            "guided": "Guided · default",
+            "careful": "Careful",
+            "measured": "Measured · opt-in",
+            "morph": "Morph · explicit",
+            "constellation": "Constellation · capacity-aware",
+        }
+        for mode, label in expected_tags.items():
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    len(re.findall(rf'class="mode-tag mode-tag--{mode}"', home)),
+                    1,
+                )
+                self.assertEqual(home.count(f">{label}</span>"), 1)
+
+    def test_homepage_explains_primary_checker_morph_and_constellation_boundaries(self):
+        home = " ".join(page_text(PAGES["home"]).lower().split())
+        for phrase in (
+            "automatic primary checker",
+            "allowlisted local model/effort evidence",
+            "one-time user confirmation",
+            "mismatch or invalid evidence blocks",
+            "explicitly selected worker model and effort",
+            "provider may be external",
+            "fresh review is required",
+            "independent, non-overlapping cards",
+            "host-advertised capacity",
+            "one primary consumes a slot",
+            "serial fallback",
+            "does not claim every provider has native effort semantics",
+            "does not claim every host supports multi-agent orchestration",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, home)
+
+    def test_current_version_copy_is_v3_3_0_on_current_pages(self):
+        for page in ("home", "install", "support"):
+            with self.subTest(page=page):
+                content = page_text(PAGES[page])
+                self.assertIn("v3.3.0", content)
+
+    def test_verification_copy_uses_future_proof_test_count(self):
+        home = page_text(PAGES["home"])
+        self.assertIn("100+ automated tests", home)
+        self.assertNotIn("109 automated tests", home)
+
     def test_install_page_has_copyable_install_command(self):
         install = page_text(PAGES["install"])
         for phrase in (
@@ -351,6 +405,10 @@ class WebsiteContractTests(unittest.TestCase):
             "codex/openai",
             "github",
             "their own terms",
+            "morph",
+            "external",
+            "bounded work packet",
+            "native effort semantics",
         ):
             self.assertIn(phrase, privacy)
 
@@ -375,6 +433,8 @@ class WebsiteContractTests(unittest.TestCase):
             "john paul furigay fusin",
             "independent open-source project",
             "not legal advice",
+            "external-provider terms",
+            "multi-agent orchestration",
         ):
             self.assertIn(phrase, terms)
         self.assertNotIn("officially endorsed by openai", terms)
@@ -784,7 +844,7 @@ class WebsiteContractTests(unittest.TestCase):
         home = page_text(PAGES["home"])
         for phrase in (
             "v3.2.0",
-            "Four modes",
+            "Six modes",
             "Quick",
             "Guided · default",
             "Careful",
@@ -839,7 +899,7 @@ class WebsiteContractTests(unittest.TestCase):
                 "objective checks plus fresh review",
                 "local privacy/no-analytics runtime posture",
                 "current repository verification passed",
-                "109 automated tests",
+                "100+ automated tests",
                 "package verification",
                 "validates behavior and contracts",
                 "does not prove Astral beats single-Sol",

--- a/website/assets/site.css
+++ b/website/assets/site.css
@@ -897,7 +897,7 @@ p {
 }
 
 .modes-grid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .mode-tag {
@@ -936,8 +936,28 @@ p {
   border: 1px solid currentColor;
 }
 
+.mode-tag--morph {
+  color: var(--violet);
+  background: var(--violet-soft);
+  border: 1px solid currentColor;
+}
+
+.mode-tag--constellation {
+  color: var(--sky);
+  background: var(--sky-soft);
+  border: 1px solid currentColor;
+}
+
 .mode-card--measured {
   border-color: color-mix(in srgb, var(--gold) 38%, var(--line));
+}
+
+.mode-card--morph {
+  border-color: color-mix(in srgb, var(--violet) 38%, var(--line));
+}
+
+.mode-card--constellation {
+  border-color: color-mix(in srgb, var(--sky) 38%, var(--line));
 }
 
 .mode-card .mode-best {
@@ -948,6 +968,28 @@ p {
 
 .mode-card .mode-best strong {
   color: var(--text-strong);
+}
+
+.mode-guard {
+  max-width: 60rem;
+  margin: 1.4rem auto 0;
+  padding: 1.15rem 1.35rem;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--line-strong);
+  border-left: 0.32rem solid var(--violet);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+}
+
+.mode-guard h3 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 1rem;
+}
+
+.mode-guard p {
+  margin: 0.45rem 0 0;
 }
 
 /* ---------- Measured mode ---------- */

--- a/website/index.html
+++ b/website/index.html
@@ -59,7 +59,7 @@
       <section class="hero" aria-labelledby="home-title">
         <div class="shell hero-grid">
           <div>
-            <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span>v3.2.0 · open-source · local plugin runtime</p>
+            <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span>v3.3.0 · open-source · local plugin runtime</p>
             <h1 id="home-title">Turn a request into a <span class="gradient-text">checked result.</span></h1>
             <p class="hero-copy">
               Astral Orchestrator gives bigger work a clear route through Codex:
@@ -75,7 +75,7 @@
             <ul class="hero-facts">
               <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>3 pinned lanes</li>
               <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>Fresh Sol review</li>
-              <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>Measured is opt-in</li>
+              <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>Six explicit modes</li>
               <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>No project-operated backend</li>
               <li><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.2 11.3 2.9 8 1.5 9.4l4.7 4.7 8-8L12.8 4.7z"></path></svg>MIT licensed</li>
             </ul>
@@ -168,7 +168,7 @@
           <div class="section-intro" data-reveal>
             <div>
               <p class="eyebrow">Pick an altitude</p>
-              <h2 id="modes-title">Four modes, one steady hand.</h2>
+              <h2 id="modes-title">Six modes, one steady hand.</h2>
             </div>
             <p>
               Tell Astral how careful to be. It <span class="hl">raises safeguards</span>
@@ -215,7 +215,40 @@
               </p>
               <p class="mode-best"><strong>Best for:</strong> a reproducible record of a route decision and its checks.</p>
             </article>
+            <article class="mode-card mode-card--morph" data-reveal>
+              <span class="mode-tag mode-tag--morph">Morph · explicit</span>
+              <h3>Choose the worker route</h3>
+              <p>
+                Morph uses an <span class="hl">explicitly selected worker model and effort</span>
+                when the host can provide that capability; the route is capability-dependent.
+                The provider may be external,
+                and a <span class="hl">fresh review is required</span> before handoff.
+              </p>
+              <p class="mode-best"><strong>Best for:</strong> a deliberate provider or capability choice.</p>
+            </article>
+            <article class="mode-card mode-card--constellation" data-reveal>
+              <span class="mode-tag mode-tag--constellation">Constellation · capacity-aware</span>
+              <h3>Parallel first wave, when safe</h3>
+              <p>
+                Constellation starts a cost-aware parallel first wave only for
+                <span class="hl">independent, non-overlapping cards</span> within
+                <span class="hl">host-advertised capacity</span>. One primary consumes a slot;
+                no extra Sol implementers run by default.
+              </p>
+              <p class="mode-best"><strong>Best for:</strong> parallelizable work with a proven serial fallback.</p>
+            </article>
           </div>
+          <aside class="mode-guard" data-reveal aria-labelledby="mode-guard-title">
+            <h3 id="mode-guard-title">Automatic primary checker</h3>
+            <p>
+              Astral first looks for <strong>allowlisted local model/effort evidence</strong>.
+              If evidence is absent, it can use a <strong>one-time user confirmation</strong>;
+              <strong>mismatch or invalid evidence blocks</strong> the route. Morph does not claim
+              every provider has native effort semantics, and Constellation does not claim
+              every host supports multi-agent orchestration: when capacity or
+              independence is uncertain, use the <strong>serial fallback</strong>.
+            </p>
+          </aside>
         </div>
       </section>
       <section class="section" id="how-it-works" aria-labelledby="workflow-title">
@@ -460,7 +493,7 @@
           </p>
 
           <p class="scope-note" data-reveal>
-            The current repository verification passed <strong>109 automated tests</strong> and
+            The current repository verification passed <strong>100+ automated tests</strong> and
             <strong>package verification</strong>. This validates behavior and contracts:
             progressive context loading, exact pinned routes, objective checks plus fresh
             review, and a local privacy/no-analytics runtime posture. It does not prove

--- a/website/install/index.html
+++ b/website/install/index.html
@@ -58,7 +58,7 @@
         <div class="shell">
           <p class="eyebrow">Quick install</p>
           <h1>Install from GitHub in two commands.</h1>
-          <p class="page-lede">Astral Orchestrator v3.2.0 installs directly from its GitHub marketplace source. This route includes the bundled exact-process launcher, which preserves the pinned Sol, Luna, and Terra model-and-effort contract without requiring native profiles.</p>
+          <p class="page-lede">Astral Orchestrator v3.3.0 installs directly from its GitHub marketplace source. This route includes the bundled exact-process launcher, which preserves the pinned Sol, Luna, and Terra model-and-effort contract without requiring native profiles.</p>
         </div>
       </header>
 

--- a/website/privacy/index.html
+++ b/website/privacy/index.html
@@ -84,6 +84,7 @@
             <article class="policy-card">
               <h2>Other services you choose</h2>
               <p>Codex/OpenAI, Vercel, GitHub, and any user-authorized tools can process information under their own terms, privacy policies, and settings. Review those services before using them, especially when a project contains sensitive material.</p>
+              <p>If you select Morph, the host-selected worker provider may be external and may process the bounded work packet under its own terms. Astral does not operate that provider or claim that every provider supports native effort semantics; check the provider and host settings before routing sensitive work.</p>
             </article>
 
             <article class="policy-card">

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -58,7 +58,7 @@
         <div class="shell">
           <p class="eyebrow">Support</p>
           <h1>Start with the public project record.</h1>
-          <p class="page-lede">The README explains installation, the v3.2.0 modes including explicit opt-in Measured, and common setup questions. The issue tracker is the right place for reproducible bugs, confusing behavior, and improvement ideas.</p>
+          <p class="page-lede">The README explains installation, the v3.3.0 six modes including explicit opt-in Measured, Morph, and Constellation, and common setup questions. The issue tracker is the right place for reproducible bugs, confusing behavior, and improvement ideas.</p>
         </div>
       </header>
 

--- a/website/terms/index.html
+++ b/website/terms/index.html
@@ -78,6 +78,7 @@
             <article class="policy-card">
               <h2>Your responsibilities</h2>
               <p>You are responsible for reviewing commands and permissions before you run them, protecting your own accounts and project data, and getting any approvals your workplace or project requires. Be especially careful with credentials, production systems, private data, publishing, payments, and irreversible actions.</p>
+              <p>When using Morph, you are also responsible for confirming that the selected worker provider may process the bounded packet, including any external-provider terms or workplace restrictions. Do not assume every provider has native effort semantics or that every host supports multi-agent orchestration.</p>
             </article>
 
             <article class="policy-card">


### PR DESCRIPTION
## Summary
- add automatic fail-closed primary route verification
- add explicit Morph and capacity-aware Constellation modes while preserving Quick, Guided, Careful, and Measured
- add Agent Plugins 1.0 portable manifest and cross-host capability boundaries
- refresh the v3.3.0 README and six-mode Vercel site

## Verification
- 123 automated tests passed
- package verification passed
- skill and Codex plugin validators passed
- fresh gpt-5.6-sol/high read-only review: SHIP