### PR TITLE
Release v3.3.1 with config-compatible Codex runtime selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.3.1 — 2026-08-09
+
+### Fixed
+
+- Exact-process and Morph launchers now select the first Codex runtime that can parse the
+  active user configuration and model catalog instead of trusting PATH order alone.
+- Dry runs now prove runtime compatibility before inference and report allowlisted runtime
+  source, version, and configuration-probe evidence.
+
+### Security
+
+- Runtime hints now require absolute executable regular files, reject Unicode control
+  characters, deduplicate resolved paths, time out closed, and never expose probe output,
+  configuration contents, credentials, or private worker packets in failure evidence.
+
 ## 3.3.0 — 2026-08-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Astral Orchestrator
 
-Astral Orchestrator v3.3.0 is an installable, open-source Codex plugin. It
+Astral Orchestrator v3.3.1 is an installable, open-source Codex plugin. It
 helps Codex turn an everyday request into a checked result: Sol stays responsible for
 the plan and final decisions, Luna handles focused work, Terra handles context-heavy
 implementation, and a fresh Sol reviewer checks the finished change.
 
 Install it now from this public GitHub marketplace source. The official ChatGPT/Codex
-directory is a separate publication surface and may lag until the v3.3.0 directory upload
+directory is a separate publication surface and may lag until the v3.3.1 directory upload
 is published. Astral Orchestrator is an independent open-source project, not affiliated
 with or endorsed by OpenAI.
 

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,6 +1,6 @@
 # Portability boundary
 
-Astral Orchestrator 3.3.0 ships two additive manifests in one package:
+Astral Orchestrator 3.3.1 ships two additive manifests in one package:
 
 - `plugin.json` is the root Agent Plugins 1.0 manifest. It supplies portable package
   identity and lets compatible hosts discover the `skills/astral-orchestrator/SKILL.md`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,10 +31,15 @@ portable package standardizes skill discovery only. On capable non-Codex hosts, 
 explicit Morph or Constellation route requires observable model, worker-context, and
 fresh-reviewer capabilities; it does not generalize fixed Codex lanes.
 
+Version 3.3.1 makes exact-process and Morph dry runs select a host-compatible Codex
+runtime by proving that the active configuration and model catalog parse before any
+worker inference. It preserves the requested model, effort, sandbox, workdir, developer
+instructions, and private standard-input packet without changing OpenCodex configuration.
+
 ## Identity and migration
 
 Version 3.0.0 was the breaking identity migration from the former Project Pilot
-identifiers. The current product version is 3.3.0. The normalized plugin, marketplace,
+identifiers. The current product version is 3.3.1. The normalized plugin, marketplace,
 skill, and profile prefix is
 astral-orchestrator; TOML agent names use astral_orchestrator. Route evidence begins
 with ASTRAL_ORCHESTRATOR_ROUTE, and persistent effort settings live at

--- a/plugins/astral-orchestrator/.codex-plugin/plugin.json
+++ b/plugins/astral-orchestrator/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "astral-orchestrator",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Beginner-friendly orchestration with Quick, Guided, Careful, Measured, and explicit opt-in Morph and Constellation modes for planning, delegating, verifying, and reviewing project work in Codex.",
   "author": {
     "name": "Demonbane18"

--- a/plugins/astral-orchestrator/plugin.json
+++ b/plugins/astral-orchestrator/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "astral-orchestrator",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A six-mode project-delivery skill with explicit Morph and Constellation worker routes for capable hosts.",
   "author": {
     "name": "Demonbane18",

--- a/plugins/astral-orchestrator/scripts/codex_runtime.py
+++ b/plugins/astral-orchestrator/scripts/codex_runtime.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Select a Codex executable that can parse the active user configuration."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path, PureWindowsPath
+from typing import Callable, Mapping, NamedTuple, Sequence
+
+
+DEFAULT_PROBE_TIMEOUT = 5.0
+MAX_CANDIDATES = 12
+
+
+class RuntimeCandidate(NamedTuple):
+    source: str
+    path: str
+
+
+class CodexRuntime(NamedTuple):
+    path: str
+    source: str
+    version: str
+    config_probe: str
+
+
+class RuntimeResolutionError(RuntimeError):
+    """Raised when no candidate can parse the active Codex configuration."""
+
+
+def _candidate(source: str, path: object) -> RuntimeCandidate:
+    return RuntimeCandidate(source, str(path))
+
+
+def runtime_candidates(
+    *,
+    platform_name: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> tuple[RuntimeCandidate, ...]:
+    """Return a small, ordered set of explicit, host, known, and PATH candidates."""
+
+    platform_name = (platform_name or sys.platform).lower()
+    environ = os.environ if environ is None else environ
+    home = Path.home() if home is None else home
+    which = shutil.which if which is None else which
+    candidates: list[RuntimeCandidate] = []
+
+    if environ.get("ASTRAL_CODEX_PATH"):
+        candidates.append(
+            _candidate("astral-override", environ["ASTRAL_CODEX_PATH"])
+        )
+    if environ.get("CODEX_CLI_PATH"):
+        candidates.append(_candidate("host-runtime", environ["CODEX_CLI_PATH"]))
+
+    if platform_name in {"darwin", "macos"}:
+        for applications in (Path("/Applications"), home / "Applications"):
+            candidates.extend(
+                (
+                    _candidate(
+                        "chatgpt-app",
+                        applications / "ChatGPT.app/Contents/Resources/codex",
+                    ),
+                    _candidate(
+                        "codex-app",
+                        applications / "Codex.app/Contents/Resources/codex",
+                    ),
+                )
+            )
+    elif platform_name in {"windows", "win32", "cygwin"}:
+        local_app_data = environ.get("LOCALAPPDATA")
+        program_files = environ.get("ProgramFiles") or environ.get("PROGRAMFILES")
+        if local_app_data:
+            root = PureWindowsPath(local_app_data)
+            candidates.extend(
+                (
+                    _candidate(
+                        "codex-app",
+                        root / "Programs/OpenAI/Codex/bin/codex.exe",
+                    ),
+                    _candidate(
+                        "codex-app", root / "OpenAI/Codex/bin/codex.exe"
+                    ),
+                )
+            )
+        if program_files:
+            candidates.append(
+                _candidate(
+                    "codex-app",
+                    PureWindowsPath(program_files)
+                    / "OpenAI/Codex/bin/codex.exe",
+                )
+            )
+    elif platform_name.startswith("linux"):
+        candidates.extend(
+            (
+                _candidate(
+                    "standalone-runtime",
+                    home / ".codex/packages/standalone/current/bin/codex",
+                ),
+                _candidate("standalone-runtime", home / ".local/bin/codex"),
+                _candidate("standalone-runtime", "/usr/local/bin/codex"),
+                _candidate("standalone-runtime", "/usr/bin/codex"),
+            )
+        )
+
+    path_candidate = which("codex")
+    if path_candidate:
+        candidates.append(_candidate("path", path_candidate))
+    return tuple(candidates[:MAX_CANDIDATES])
+
+
+def _has_control_characters(value: str) -> bool:
+    return any(unicodedata.category(character) == "Cc" for character in value)
+
+
+def _validated_path(candidate: RuntimeCandidate) -> tuple[Path | None, str | None]:
+    raw_path = candidate.path
+    if not raw_path or _has_control_characters(raw_path):
+        return None, "invalid path"
+
+    path = Path(raw_path)
+    if not path.is_absolute():
+        return None, "path is not absolute"
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None, "path is unavailable"
+
+    if _has_control_characters(str(resolved)):
+        return None, "invalid resolved path"
+    try:
+        if not resolved.is_file():
+            return None, "path is not a regular file"
+        if not os.access(resolved, os.X_OK):
+            return None, "path is not executable"
+    except OSError:
+        return None, "path could not be inspected"
+    return resolved, None
+
+
+def _runtime_version(
+    path: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+    timeout: float,
+) -> str:
+    try:
+        result = runner(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unavailable"
+    if result.returncode != 0 or not isinstance(result.stdout, str):
+        return "unavailable"
+
+    version = result.stdout.strip()
+    if re.fullmatch(r"codex(?:-cli)? v?[0-9][0-9A-Za-z.+_-]{0,63}", version):
+        return version
+    return "unavailable"
+
+
+def _failure_message(failures: Sequence[str]) -> str:
+    details = "; ".join(failures) if failures else "no candidates were available"
+    return f"no compatible Codex runtime ({details})"
+
+
+def resolve_codex_runtime(
+    *,
+    platform_name: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    home: Path | None = None,
+    which: Callable[[str], str | None] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    timeout: float = DEFAULT_PROBE_TIMEOUT,
+) -> CodexRuntime:
+    """Select the first candidate whose feature probe parses the active config."""
+
+    if timeout <= 0:
+        raise ValueError("probe timeout must be positive")
+    runner = subprocess.run if runner is None else runner
+    failures: list[str] = []
+    seen_paths: set[str] = set()
+
+    for candidate in runtime_candidates(
+        platform_name=platform_name,
+        environ=environ,
+        home=home,
+        which=which,
+    ):
+        path, validation_error = _validated_path(candidate)
+        if path is None:
+            failures.append(f"{candidate.source}: {validation_error}")
+            continue
+
+        identity = os.path.normcase(str(path))
+        if identity in seen_paths:
+            continue
+        seen_paths.add(identity)
+
+        try:
+            probe = runner(
+                [str(path), "features", "list"],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append(f"{candidate.source}: probe timeout")
+            continue
+        except OSError:
+            failures.append(f"{candidate.source}: probe could not start")
+            continue
+
+        if probe.returncode != 0:
+            failures.append(
+                f"{candidate.source}: probe exited {probe.returncode}"
+            )
+            continue
+
+        return CodexRuntime(
+            path=str(path),
+            source=candidate.source,
+            version=_runtime_version(path, runner, timeout),
+            config_probe="pass",
+        )
+
+    raise RuntimeResolutionError(_failure_message(failures))

--- a/plugins/astral-orchestrator/scripts/run-agent.py
+++ b/plugins/astral-orchestrator/scripts/run-agent.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import shutil
 import stat
 import subprocess
 import sys
@@ -23,6 +22,10 @@ from effort_settings import (  # noqa: E402
     EffortSettingsError,
     default_settings_path,
     load_efforts,
+)
+from codex_runtime import (  # noqa: E402
+    RuntimeResolutionError,
+    resolve_codex_runtime,
 )
 
 
@@ -168,6 +171,11 @@ def main() -> int:
     if not workdir.is_dir():
         fail(f"workdir must be an existing directory: {workdir}")
 
+    try:
+        runtime = resolve_codex_runtime()
+    except RuntimeResolutionError as error:
+        fail(str(error))
+
     evidence = {
         "role": args.role,
         "agent_name": contract["agent_name"],
@@ -183,17 +191,16 @@ def main() -> int:
         "sandbox": contract["sandbox"],
         "workdir": str(workdir),
         "prompt_bytes": prompt_bytes,
+        "codex_runtime_source": runtime.source,
+        "codex_version": runtime.version,
+        "codex_config_probe": runtime.config_probe,
     }
     if args.dry_run:
         print(json.dumps(evidence, separators=(",", ":"), sort_keys=True))
         return 0
 
-    codex = shutil.which("codex")
-    if codex is None:
-        fail("the codex command is unavailable")
-
     command = [
-        codex,
+        runtime.path,
         "exec",
         "--model",
         contract["model"],

--- a/plugins/astral-orchestrator/scripts/run-morph-agent.py
+++ b/plugins/astral-orchestrator/scripts/run-morph-agent.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -17,6 +16,10 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from effort_settings import ALLOWED_EFFORTS  # noqa: E402
+from codex_runtime import (  # noqa: E402
+    RuntimeResolutionError,
+    resolve_codex_runtime,
+)
 
 
 MODEL_CHARACTERS = frozenset(
@@ -95,7 +98,15 @@ def main() -> int:
     if not workdir.is_dir():
         fail(f"workdir must be an existing directory: {workdir}")
 
+    try:
+        runtime = resolve_codex_runtime()
+    except RuntimeResolutionError as error:
+        fail(str(error))
+
     evidence = {
+        "codex_config_probe": runtime.config_probe,
+        "codex_runtime_source": runtime.source,
+        "codex_version": runtime.version,
         "effort_semantics": "requested-only",
         "model": args.model,
         "prompt_bytes": len(prompt),
@@ -109,12 +120,8 @@ def main() -> int:
         print(json.dumps(evidence, separators=(",", ":"), sort_keys=True))
         return 0
 
-    codex = shutil.which("codex")
-    if codex is None:
-        fail("the codex command is unavailable")
-
     command = [
-        codex,
+        runtime.path,
         "exec",
         "--model",
         args.model,

--- a/plugins/astral-orchestrator/scripts/verify.sh
+++ b/plugins/astral-orchestrator/scripts/verify.sh
@@ -67,8 +67,8 @@ manifest_path, portable_manifest_path, skill_path, modes_path, templates_path, r
 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 if manifest.get("name") != "astral-orchestrator":
     raise SystemExit("manifest name must be astral-orchestrator")
-if manifest.get("version") != "3.3.0":
-    raise SystemExit("manifest version must be Astral Orchestrator v3.3.0")
+if manifest.get("version") != "3.3.1":
+    raise SystemExit("manifest version must be Astral Orchestrator v3.3.1")
 if manifest.get("skills") != "./skills/":
     raise SystemExit("manifest skills path must be ./skills/")
 if manifest.get("license") != "MIT":

--- a/plugins/astral-orchestrator/scripts/verify.sh
+++ b/plugins/astral-orchestrator/scripts/verify.sh
@@ -26,6 +26,7 @@ inspector=$plugin_dir/scripts/inspect-agent-runtime.sh
 primary_checker=$plugin_dir/scripts/check-primary.py
 launcher=$plugin_dir/scripts/run-agent.py
 morph_launcher=$plugin_dir/scripts/run-morph-agent.py
+codex_runtime=$plugin_dir/scripts/codex_runtime.py
 effort_settings=$plugin_dir/scripts/effort_settings.py
 effort_configurator=$plugin_dir/scripts/configure-effort.py
 benchmark_scorecard=$plugin_dir/scripts/benchmark-scorecard.py
@@ -45,7 +46,7 @@ cmp -s "$canonical_license" "$plugin_license" || fail "distributable notice diff
 cmp -s "$canonical_notice" "$plugin_notice" || fail "distributable notice differs from repository root: NOTICE.md"
 grep -Fq "($canonical_improvements_url)" "$canonical_notice" || fail "canonical NOTICE must link to the repository improvements document"
 
-for required in "$manifest" "$portable_manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$morph" "$constellation" "$portable_hosts" "$installer" "$inspector" "$primary_checker" "$launcher" "$morph_launcher" "$effort_settings" "$effort_configurator" "$benchmark_scorecard" "$effort_wrapper"; do
+for required in "$manifest" "$portable_manifest" "$skill" "$modes" "$templates" "$routing" "$measured" "$morph" "$constellation" "$portable_hosts" "$installer" "$inspector" "$primary_checker" "$launcher" "$morph_launcher" "$codex_runtime" "$effort_settings" "$effort_configurator" "$benchmark_scorecard" "$effort_wrapper"; do
   [ -f "$required" ] || fail "required file is missing: $required"
 done
 

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/morph-mode.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/morph-mode.md
@@ -20,6 +20,14 @@ required. Only a bounded worker card may use a user-selected model.
      --workdir <workspace> --prompt-file <private-card> --dry-run
    ```
 
+   The dry run selects a compatible Codex runtime and runs `codex features list` so the
+   active user configuration and model catalog must parse before launch. It does not send
+   the private card to a model. Astral checks an explicit `ASTRAL_CODEX_PATH` override,
+   the host's `CODEX_CLI_PATH` hint, known installed app/runtime locations, and finally
+   the current `codex` command. Each path must be absolute, executable, and a regular
+   file. If every candidate fails, stop and report the sanitized candidate-source errors;
+   do not edit the user's configuration or catalog.
+
 4. Start the same command without `--dry-run` only after the card is ready. It launches
    `codex exec` with the exact worker model, requested effort, and workspace-write
    sandbox. Capture its `ASTRAL_ORCHESTRATOR_ROUTE` evidence, process identity, exit
@@ -29,18 +37,21 @@ required. Only a bounded worker card may use a user-selected model.
    packet. Do not use a broad or recursive deletion, and do not remove any other packet
    or user file.
 
-The evidence labels the requested effort separately from upstream-native effort. An
-accepted label is **requested-only** and does not verify upstream-native effort semantics.
-Depending on the configured provider and model, effort can be native, mapped, clamped,
-emulated, or absent. Do not call it native unless independent upstream evidence proves
-that fact.
+The evidence labels the requested effort separately from upstream-native effort and also
+records the selected runtime source, its allowlisted version, and a passing configuration
+probe. It never includes the executable path, environment values, configuration contents,
+credentials, or private packet. An accepted effort label is **requested-only** and does
+not verify upstream-native effort semantics. Depending on the configured provider and
+model, effort can be native, mapped, clamped, emulated, or absent. Do not call it native
+unless independent upstream evidence proves that fact.
 
 ## OpenCodex boundary
 
 OpenCodex is optional and independently installed and configured by the user. Astral
 never modifies ~/.opencodex, starts services, installs packages, handles provider
-credentials, or assumes provider terms-of-service compatibility. It adds no network
-dependency: the launcher invokes only the user’s existing `codex` command.
+credentials, rewrites `$CODEX_HOME/config.toml` or a model catalog, or assumes provider
+terms-of-service compatibility. It adds no network dependency: the launcher invokes only
+a compatible runtime from the user's existing Codex installation.
 
 Provider/model support and effort semantics are capability-dependent. A user must wire an
 OpenCodex provider route to Codex separately before Morph can use it. If the provider,

--- a/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
+++ b/plugins/astral-orchestrator/skills/astral-orchestrator/references/routing-and-preflight.md
@@ -118,10 +118,21 @@ python3 run-agent.py --role <luna|terra|reviewer> --workdir <workspace> --prompt
 The launcher reads the shipped profile, reads the effective effort settings, pins the
 model and configured effort on `codex exec`, injects the profile's developer
 instructions that forbid further delegation, and selects workspace-write for workers
-or read-only for the reviewer. Its evidence marks whether the effort is the default and
-whether a native profile would be compatible. A successful dry-run proves this bundled
-exact-process contract without requiring installed native profiles. Remove only the
-exact temporary packet after the process exits. A non-zero exit blocks the lane.
+or read-only for the reviewer. Before either a dry run or launch, it checks a small set of
+Codex runtimes supplied by Astral, the host, the installed app, and the current command
+environment. It selects the first runtime whose `codex features list` check proves that
+the active user configuration and model catalog can be parsed. This check does not send
+the work packet to a model. `ASTRAL_CODEX_PATH` may name an absolute executable as an
+explicit override; an inherited `CODEX_CLI_PATH` is treated as a host hint. Invalid or
+incompatible candidates are rejected, and no model or provider is substituted.
+
+The allowlisted route evidence records `codex_runtime_source`, `codex_version`, and
+`codex_config_probe: "pass"` without printing the executable path, candidate environment
+values, configuration contents, credentials, or packet. It also marks whether the effort
+is the default and whether a native profile would be compatible. A successful dry-run
+therefore proves both this bundled exact-process contract and Codex configuration parsing
+without requiring installed native profiles or invoking inference. Remove only the exact
+temporary packet after the process exits. A non-zero exit blocks the lane.
 
 ## Spawn and runtime evidence
 
@@ -135,6 +146,8 @@ After launch, collect runtime evidence showing:
 
 - the native spawn used the exact custom `agent_type`, or the launcher header names the
   exact role;
+- an exact-process launcher reports a passing Codex configuration probe and the selected
+  runtime source and version;
 - the returned task or process session id identifies that lane;
 - `model` equals the role's required model;
 - `effort` equals the role's configured effort;

--- a/release/astral-release-ledger.json
+++ b/release/astral-release-ledger.json
@@ -139,6 +139,31 @@
       "evidence": "OpenAI Platform accepted the v3.3.0 ZIP, converted the Agent Plugins root manifest to Codex format, populated six-mode metadata and three prompts, and saved draft appsub_6a786a4fd6c4819188380cbc396a39f4. Skill scanning remains in progress and four developer legal/policy attestations remain unchecked.",
       "url": "https://platform.openai.com/plugins/plugins_6a702dc6da648191a24bb8b82093f3cc/submissions/appsub_6a786a4fd6c4819188380cbc396a39f4",
       "commit": "80d836eee004075b13fa160c298f9d1ec60a8791"
+    },
+    {
+      "surface": "openai_submission",
+      "version": "3.3.0",
+      "status": "approved",
+      "observed_at": "2026-08-09T22:33:32+08:00",
+      "evidence": "OpenAI Platform in Opera GX displayed Viewing the approved version for Astral Orchestrator v3.3.0. This submission predates runtime-selection fix commit 4850c85 and therefore does not contain that fix.",
+      "url": "https://platform.openai.com/plugins/plugins_6a702dc6da648191a24bb8b82093f3cc/submissions/appsub_6a786a4fd6c4819188380cbc396a39f4",
+      "commit": "80d836eee004075b13fa160c298f9d1ec60a8791"
+    },
+    {
+      "surface": "openai_directory",
+      "version": "3.2.0",
+      "status": "published",
+      "observed_at": "2026-08-09T22:33:32+08:00",
+      "evidence": "The public ChatGPT/Codex plugin directory in Opera GX displayed Astral Orchestrator version 3.2.0 and the older four-mode description.",
+      "url": "https://chatgpt.com/plugins/plugins_6a702dc6da648191a24bb8b82093f3cc"
+    },
+    {
+      "surface": "source",
+      "version": "3.3.1",
+      "status": "draft",
+      "observed_at": "2026-08-09T22:43:29+08:00",
+      "evidence": "PR #9 working tree declares v3.3.1; 133 tests, package verification, both skill validators, plugin validation, and fresh release review passed. Merge and immutable release packaging remain pending.",
+      "url": "https://github.com/Demonbane18/astral-orchestrator/pull/9"
     }
   ]
 }

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -41,6 +41,7 @@ INSPECT_RUNTIME = PLUGIN / "scripts/inspect-agent-runtime.sh"
 CHECK_PRIMARY = PLUGIN / "scripts/check-primary.py"
 RUN_AGENT = PLUGIN / "scripts/run-agent.py"
 RUN_MORPH_AGENT = PLUGIN / "scripts/run-morph-agent.py"
+CODEX_RUNTIME = PLUGIN / "scripts/codex_runtime.py"
 CONFIGURE_EFFORT = PLUGIN / "scripts/configure-effort.py"
 EFFORT_SETTINGS = PLUGIN / "scripts/effort_settings.py"
 CONFIGURE_EFFORT_WRAPPER = ROOT / "scripts/configure-effort.sh"
@@ -72,6 +73,36 @@ def read(path: Path) -> str:
 
 def load_json(path: Path):
     return json.loads(read(path))
+
+
+def make_fake_codex_runtime(
+    root: Path, name: str = "codex", *, compatible: bool = True
+) -> Path:
+    runtime = root / name
+    feature_exit = 0 if compatible else 42
+    runtime.write_text(
+        "#!/bin/sh\n"
+        f"if [ \"$1 $2\" = \"features list\" ]; then exit {feature_exit}; fi\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'codex-cli 99.0-test'; exit 0; fi\n"
+        "exit 97\n",
+        encoding="utf-8",
+    )
+    runtime.chmod(0o700)
+    return runtime
+
+
+def load_script(name: str, path: Path):
+    specification = importlib.util.spec_from_file_location(name, path)
+    if specification is None or specification.loader is None:
+        raise AssertionError(f"could not load script: {path}")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[name] = module
+    try:
+        specification.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return module
 
 
 class MarketplaceTests(unittest.TestCase):
@@ -938,6 +969,7 @@ class SkillContractTests(unittest.TestCase):
     def test_morph_launcher_validates_private_packets_and_marks_effort_as_requested_only(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            codex_runtime = make_fake_codex_runtime(root)
             workdir = root / "work"
             workdir.mkdir()
             prompt = root / "packet.txt"
@@ -962,6 +994,7 @@ class SkillContractTests(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
+                env={**os.environ, "ASTRAL_CODEX_PATH": str(codex_runtime)},
             )
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             evidence = json.loads(result.stdout)
@@ -991,6 +1024,7 @@ class SkillContractTests(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
+                env={**os.environ, "ASTRAL_CODEX_PATH": str(codex_runtime)},
             )
             self.assertNotEqual(invalid_model.returncode, 0)
             self.assertIn("model", invalid_model.stderr.lower())
@@ -1034,7 +1068,16 @@ class SkillContractTests(unittest.TestCase):
             ]
             with (
                 mock.patch.object(sys, "argv", argv),
-                mock.patch.object(launcher.shutil, "which", return_value="/test/codex"),
+                mock.patch.object(
+                    launcher,
+                    "resolve_codex_runtime",
+                    return_value=mock.Mock(
+                        path="/test/codex",
+                        source="host-runtime",
+                        version="codex-cli test",
+                        config_probe="pass",
+                    ),
+                ),
                 mock.patch.object(launcher.subprocess, "run", side_effect=fake_run),
                 redirect_stdout(output),
             ):
@@ -1086,6 +1129,7 @@ class SkillContractTests(unittest.TestCase):
             ),
         }
         with tempfile.TemporaryDirectory() as directory:
+            codex_runtime = make_fake_codex_runtime(Path(directory))
             workdir = Path(directory) / "work"
             workdir.mkdir()
             prompt = Path(directory) / "packet.txt"
@@ -1111,6 +1155,7 @@ class SkillContractTests(unittest.TestCase):
                     check=False,
                     capture_output=True,
                     text=True,
+                    env={**os.environ, "ASTRAL_CODEX_PATH": str(codex_runtime)},
                 )
                 self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
                 evidence = json.loads(result.stdout)
@@ -1167,7 +1212,16 @@ class SkillContractTests(unittest.TestCase):
                 ]
                 with (
                     mock.patch.object(sys, "argv", argv),
-                    mock.patch.object(launcher.shutil, "which", return_value="/test/codex"),
+                    mock.patch.object(
+                        launcher,
+                        "resolve_codex_runtime",
+                        return_value=mock.Mock(
+                            path="/test/codex",
+                            source="host-runtime",
+                            version="codex-cli test",
+                            config_probe="pass",
+                        ),
+                    ),
                     mock.patch.object(launcher.subprocess, "run", side_effect=fake_run),
                     redirect_stdout(output),
                 ):
@@ -1234,7 +1288,7 @@ class SkillContractTests(unittest.TestCase):
             ]
             with (
                 mock.patch.object(sys, "argv", argv),
-                mock.patch.object(launcher.shutil, "which") as find_codex,
+                mock.patch.object(launcher, "resolve_codex_runtime") as find_codex,
                 mock.patch.object(launcher.subprocess, "run") as start_codex,
                 redirect_stderr(errors),
             ):
@@ -1339,6 +1393,7 @@ class SkillContractTests(unittest.TestCase):
     def test_process_launcher_uses_configured_effort_and_marks_native_mismatch(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            codex_runtime = make_fake_codex_runtime(root)
             settings = root / "effort-levels.toml"
             settings.write_text(
                 """[effort]
@@ -1378,6 +1433,7 @@ reviewer = "xhigh"
                     check=False,
                     capture_output=True,
                     text=True,
+                    env={**os.environ, "ASTRAL_CODEX_PATH": str(codex_runtime)},
                 )
                 self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
                 evidence = json.loads(result.stdout)
@@ -1467,6 +1523,526 @@ reviewer = "xhigh"
         self.assertTrue(skill.startswith("---\nname: astral-orchestrator\n"))
         self.assertNotIn("[TODO", skill)
         self.assertNotIn("YOUR-NAME", skill)
+
+
+class CodexRuntimeResolutionTests(unittest.TestCase):
+    def load_runtime(self):
+        return load_script("astral_orchestrator_codex_runtime_tests", CODEX_RUNTIME)
+
+    def test_incompatible_path_runtime_is_skipped_for_compatible_host_runtime(self):
+        runtime = self.load_runtime()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path_runtime = make_fake_codex_runtime(root, "path-codex")
+            app_runtime = make_fake_codex_runtime(root, "app-codex")
+            calls = []
+
+            def runner(command, **kwargs):
+                calls.append((command, kwargs))
+                if command[1:] == ["features", "list"]:
+                    if command[0] == str(path_runtime.resolve()):
+                        return subprocess.CompletedProcess(
+                            command,
+                            1,
+                            "",
+                            "unknown variant audio from private catalog",
+                        )
+                    return subprocess.CompletedProcess(command, 0, "features", "")
+                if command[1:] == ["--version"]:
+                    return subprocess.CompletedProcess(
+                        command, 0, "codex-cli 0.147.0-alpha.6.5\n", ""
+                    )
+                self.fail(f"unexpected inference command: {command}")
+
+            candidates = [
+                runtime.RuntimeCandidate("path", str(path_runtime)),
+                runtime.RuntimeCandidate("chatgpt-app", str(app_runtime)),
+            ]
+            with mock.patch.object(
+                runtime, "runtime_candidates", return_value=candidates
+            ):
+                selected = runtime.resolve_codex_runtime(runner=runner)
+
+        self.assertEqual(selected.path, str(app_runtime.resolve()))
+        self.assertEqual(selected.source, "chatgpt-app")
+        self.assertEqual(selected.version, "codex-cli 0.147.0-alpha.6.5")
+        self.assertEqual(selected.config_probe, "pass")
+        self.assertEqual(
+            [command[1:] for command, _ in calls],
+            [["features", "list"], ["features", "list"], ["--version"]],
+        )
+        for command, kwargs in calls:
+            self.assertNotIn("exec", command)
+            self.assertTrue(kwargs["capture_output"])
+            self.assertTrue(kwargs["text"])
+
+    def test_invalid_hinted_paths_are_rejected_without_being_executed(self):
+        runtime = self.load_runtime()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fallback = make_fake_codex_runtime(root, "fallback-codex")
+            non_executable = root / "non-executable-codex"
+            non_executable.write_text("not executable\n", encoding="utf-8")
+            non_executable.chmod(0o600)
+            directory_candidate = root / "codex-directory"
+            directory_candidate.mkdir()
+            unicode_control = make_fake_codex_runtime(
+                root, "codex-\u0085-control"
+            )
+            invalid_paths = {
+                "missing": root / "missing-codex",
+                "non-executable": non_executable,
+                "directory": directory_candidate,
+                "control-character": f"{root}/codex\nsecret",
+                "unicode-control-character": unicode_control,
+            }
+
+            for label, invalid_path in invalid_paths.items():
+                with self.subTest(label=label):
+                    calls = []
+
+                    def runner(command, **kwargs):
+                        calls.append(command)
+                        if command[1:] == ["features", "list"]:
+                            return subprocess.CompletedProcess(command, 0, "", "")
+                        if command[1:] == ["--version"]:
+                            return subprocess.CompletedProcess(
+                                command, 0, "codex-cli test\n", ""
+                            )
+                        self.fail(f"unexpected inference command: {command}")
+
+                    candidates = [
+                        runtime.RuntimeCandidate("astral-override", str(invalid_path)),
+                        runtime.RuntimeCandidate("path", str(fallback)),
+                    ]
+                    with mock.patch.object(
+                        runtime, "runtime_candidates", return_value=candidates
+                    ):
+                        selected = runtime.resolve_codex_runtime(runner=runner)
+
+                    self.assertEqual(selected.path, str(fallback.resolve()))
+                    self.assertEqual(selected.source, "path")
+                    self.assertEqual(
+                        calls,
+                        [
+                            [str(fallback.resolve()), "features", "list"],
+                            [str(fallback.resolve()), "--version"],
+                        ],
+                    )
+
+    def test_duplicate_resolved_paths_are_probed_only_once(self):
+        runtime = self.load_runtime()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            duplicate = make_fake_codex_runtime(root, "duplicate-codex")
+            fallback = make_fake_codex_runtime(root, "fallback-codex")
+            feature_calls = []
+
+            def runner(command, **kwargs):
+                if command[1:] == ["features", "list"]:
+                    feature_calls.append(command[0])
+                    return subprocess.CompletedProcess(
+                        command,
+                        0 if command[0] == str(fallback.resolve()) else 1,
+                        "",
+                        "",
+                    )
+                return subprocess.CompletedProcess(command, 0, "codex-cli test\n", "")
+
+            candidates = [
+                runtime.RuntimeCandidate("astral-override", str(duplicate)),
+                runtime.RuntimeCandidate("host-runtime", str(duplicate)),
+                runtime.RuntimeCandidate("path", str(fallback)),
+            ]
+            with mock.patch.object(
+                runtime, "runtime_candidates", return_value=candidates
+            ):
+                selected = runtime.resolve_codex_runtime(runner=runner)
+
+        self.assertEqual(selected.source, "path")
+        self.assertEqual(
+            feature_calls,
+            [str(duplicate.resolve()), str(fallback.resolve())],
+        )
+
+    def test_all_failed_probes_fail_closed_without_leaking_output_or_inferring(self):
+        runtime = self.load_runtime()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = make_fake_codex_runtime(root, "first-codex")
+            second = make_fake_codex_runtime(root, "second-codex")
+            calls = []
+            packet_secret = "PRIVATE_WORKER_PACKET_DO_NOT_PRINT"
+            config_secret = "provider_api_key=CONFIG_SECRET_DO_NOT_PRINT"
+
+            def runner(command, **kwargs):
+                calls.append(command)
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    f"catalog contained {config_secret}",
+                    f"parse failed near {packet_secret}",
+                )
+
+            candidates = [
+                runtime.RuntimeCandidate("host-runtime", str(first)),
+                runtime.RuntimeCandidate("path", str(second)),
+            ]
+            with mock.patch.object(
+                runtime, "runtime_candidates", return_value=candidates
+            ):
+                with self.assertRaises(runtime.RuntimeResolutionError) as raised:
+                    runtime.resolve_codex_runtime(runner=runner)
+
+        message = str(raised.exception)
+        self.assertIn("host-runtime", message)
+        self.assertIn("path", message)
+        self.assertNotIn(config_secret, message)
+        self.assertNotIn(packet_secret, message)
+        self.assertEqual(
+            calls,
+            [
+                [str(first.resolve()), "features", "list"],
+                [str(second.resolve()), "features", "list"],
+            ],
+        )
+        self.assertTrue(all("exec" not in command for command in calls))
+
+    def test_probe_timeout_fails_closed(self):
+        runtime = self.load_runtime()
+
+        with tempfile.TemporaryDirectory() as directory:
+            candidate = make_fake_codex_runtime(Path(directory))
+            calls = []
+
+            def runner(command, **kwargs):
+                calls.append((command, kwargs))
+                raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+            with mock.patch.object(
+                runtime,
+                "runtime_candidates",
+                return_value=[runtime.RuntimeCandidate("path", str(candidate))],
+            ):
+                with self.assertRaises(runtime.RuntimeResolutionError) as raised:
+                    runtime.resolve_codex_runtime(runner=runner, timeout=0.25)
+
+        self.assertIn("path", str(raised.exception))
+        self.assertIn("timeout", str(raised.exception).lower())
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0][1:], ["features", "list"])
+        self.assertEqual(calls[0][1]["timeout"], 0.25)
+
+    def test_morph_dry_run_uses_real_probes_for_mismatch_and_all_fail_fixtures(self):
+        runtime = load_script("codex_runtime", CODEX_RUNTIME)
+        launcher = load_script(
+            "astral_orchestrator_run_morph_fixture_test", RUN_MORPH_AGENT
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            incompatible = make_fake_codex_runtime(
+                root, "path-codex", compatible=False
+            )
+            compatible = make_fake_codex_runtime(root, "host-codex")
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            packet = "PRIVATE_FIXTURE_PACKET"
+            prompt.write_text(packet, encoding="utf-8")
+            prompt.chmod(0o600)
+            argv = [
+                str(RUN_MORPH_AGENT),
+                "--model",
+                "opencodex/worker-model",
+                "--effort",
+                "high",
+                "--workdir",
+                str(workdir),
+                "--prompt-file",
+                str(prompt),
+                "--dry-run",
+            ]
+
+            mismatch = [
+                runtime.RuntimeCandidate("path", str(incompatible)),
+                runtime.RuntimeCandidate("host-runtime", str(compatible)),
+            ]
+            output = io.StringIO()
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(
+                    runtime, "runtime_candidates", return_value=mismatch
+                ),
+                redirect_stdout(output),
+            ):
+                self.assertEqual(launcher.main(), 0)
+
+            evidence = json.loads(output.getvalue())
+            self.assertEqual(evidence["codex_runtime_source"], "host-runtime")
+            self.assertEqual(evidence["codex_config_probe"], "pass")
+            self.assertNotIn(packet, output.getvalue())
+
+            errors = io.StringIO()
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(
+                    runtime,
+                    "runtime_candidates",
+                    return_value=[
+                        runtime.RuntimeCandidate("path", str(incompatible))
+                    ],
+                ),
+                redirect_stderr(errors),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    launcher.main()
+
+            self.assertEqual(raised.exception.code, 1)
+            self.assertIn("no compatible Codex runtime", errors.getvalue())
+            self.assertNotIn(packet, errors.getvalue())
+
+    def test_candidate_generation_is_ordered_and_cross_platform(self):
+        runtime = self.load_runtime()
+
+        darwin = runtime.runtime_candidates(
+            platform_name="Darwin",
+            environ={
+                "ASTRAL_CODEX_PATH": "/override/codex",
+                "CODEX_CLI_PATH": "/host/codex",
+            },
+            home=Path("/Users/tester"),
+            which=lambda _: "/path/codex",
+        )
+        self.assertEqual(
+            [(candidate.source, candidate.path) for candidate in darwin],
+            [
+                ("astral-override", "/override/codex"),
+                ("host-runtime", "/host/codex"),
+                ("chatgpt-app", "/Applications/ChatGPT.app/Contents/Resources/codex"),
+                ("codex-app", "/Applications/Codex.app/Contents/Resources/codex"),
+                (
+                    "chatgpt-app",
+                    "/Users/tester/Applications/ChatGPT.app/Contents/Resources/codex",
+                ),
+                (
+                    "codex-app",
+                    "/Users/tester/Applications/Codex.app/Contents/Resources/codex",
+                ),
+                ("path", "/path/codex"),
+            ],
+        )
+
+        windows = runtime.runtime_candidates(
+            platform_name="Windows",
+            environ={
+                "LOCALAPPDATA": r"C:\Users\tester\AppData\Local",
+                "ProgramFiles": r"C:\Program Files",
+            },
+            home=Path("C:/Users/tester"),
+            which=lambda _: r"C:\Path\codex.exe",
+        )
+        self.assertEqual(
+            [(candidate.source, candidate.path) for candidate in windows],
+            [
+                (
+                    "codex-app",
+                    r"C:\Users\tester\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe",
+                ),
+                (
+                    "codex-app",
+                    r"C:\Users\tester\AppData\Local\OpenAI\Codex\bin\codex.exe",
+                ),
+                ("codex-app", r"C:\Program Files\OpenAI\Codex\bin\codex.exe"),
+                ("path", r"C:\Path\codex.exe"),
+            ],
+        )
+
+        linux = runtime.runtime_candidates(
+            platform_name="Linux",
+            environ={},
+            home=Path("/home/tester"),
+            which=lambda _: "/opt/bin/codex",
+        )
+        self.assertEqual(
+            [(candidate.source, candidate.path) for candidate in linux],
+            [
+                (
+                    "standalone-runtime",
+                    "/home/tester/.codex/packages/standalone/current/bin/codex",
+                ),
+                ("standalone-runtime", "/home/tester/.local/bin/codex"),
+                ("standalone-runtime", "/usr/local/bin/codex"),
+                ("standalone-runtime", "/usr/bin/codex"),
+                ("path", "/opt/bin/codex"),
+            ],
+        )
+
+    def test_both_launchers_import_the_same_shared_resolver(self):
+        runtime = load_script("codex_runtime", CODEX_RUNTIME)
+        process_launcher = load_script(
+            "astral_orchestrator_run_agent_shared_resolver_test", RUN_AGENT
+        )
+        morph_launcher = load_script(
+            "astral_orchestrator_run_morph_shared_resolver_test", RUN_MORPH_AGENT
+        )
+
+        self.assertIs(
+            process_launcher.resolve_codex_runtime,
+            runtime.resolve_codex_runtime,
+        )
+        self.assertIs(
+            morph_launcher.resolve_codex_runtime,
+            runtime.resolve_codex_runtime,
+        )
+
+    def test_dry_runs_probe_runtime_and_emit_only_allowlisted_runtime_evidence(self):
+        runtime = load_script("codex_runtime", CODEX_RUNTIME)
+        selected = runtime.CodexRuntime(
+            path="/selected/codex",
+            source="host-runtime",
+            version="codex-cli test-version",
+            config_probe="pass",
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            packet = "PRIVATE_DRY_RUN_PACKET"
+            prompt.write_text(packet, encoding="utf-8")
+            prompt.chmod(0o600)
+            settings = root / "missing-effort-levels.toml"
+
+            cases = (
+                (
+                    "astral_orchestrator_run_agent_dry_run_test",
+                    RUN_AGENT,
+                    [
+                        "--role",
+                        "luna",
+                        "--workdir",
+                        str(workdir),
+                        "--prompt-file",
+                        str(prompt),
+                        "--settings-file",
+                        str(settings),
+                        "--dry-run",
+                    ],
+                ),
+                (
+                    "astral_orchestrator_run_morph_dry_run_test",
+                    RUN_MORPH_AGENT,
+                    [
+                        "--model",
+                        "opencodex/worker-model",
+                        "--effort",
+                        "high",
+                        "--workdir",
+                        str(workdir),
+                        "--prompt-file",
+                        str(prompt),
+                        "--dry-run",
+                    ],
+                ),
+            )
+            for name, script, arguments in cases:
+                with self.subTest(script=script.name):
+                    launcher = load_script(name, script)
+                    output = io.StringIO()
+                    with (
+                        mock.patch.object(sys, "argv", [str(script), *arguments]),
+                        mock.patch.object(
+                            launcher, "resolve_codex_runtime", return_value=selected
+                        ) as resolve,
+                        mock.patch.object(launcher.subprocess, "run") as start_codex,
+                        redirect_stdout(output),
+                    ):
+                        self.assertEqual(launcher.main(), 0)
+
+                    evidence = json.loads(output.getvalue())
+                    resolve.assert_called_once_with()
+                    start_codex.assert_not_called()
+                    self.assertEqual(evidence["codex_runtime_source"], "host-runtime")
+                    self.assertEqual(evidence["codex_version"], "codex-cli test-version")
+                    self.assertEqual(evidence["codex_config_probe"], "pass")
+                    self.assertNotIn("codex_runtime_path", evidence)
+                    self.assertNotIn(packet, output.getvalue())
+
+    def test_launchers_fail_before_inference_when_runtime_resolution_fails(self):
+        runtime = load_script("codex_runtime", CODEX_RUNTIME)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            workdir = root / "work"
+            workdir.mkdir()
+            prompt = root / "packet.txt"
+            packet = "PRIVATE_PACKET_MUST_NOT_LEAK"
+            prompt.write_text(packet, encoding="utf-8")
+            prompt.chmod(0o600)
+            settings = root / "missing-effort-levels.toml"
+
+            cases = (
+                (
+                    "astral_orchestrator_run_agent_resolution_failure_test",
+                    RUN_AGENT,
+                    [
+                        "--role",
+                        "reviewer",
+                        "--workdir",
+                        str(workdir),
+                        "--prompt-file",
+                        str(prompt),
+                        "--settings-file",
+                        str(settings),
+                    ],
+                ),
+                (
+                    "astral_orchestrator_run_morph_resolution_failure_test",
+                    RUN_MORPH_AGENT,
+                    [
+                        "--model",
+                        "opencodex/worker-model",
+                        "--effort",
+                        "high",
+                        "--workdir",
+                        str(workdir),
+                        "--prompt-file",
+                        str(prompt),
+                    ],
+                ),
+            )
+            for name, script, arguments in cases:
+                with self.subTest(script=script.name):
+                    launcher = load_script(name, script)
+                    output = io.StringIO()
+                    errors = io.StringIO()
+                    with (
+                        mock.patch.object(sys, "argv", [str(script), *arguments]),
+                        mock.patch.object(
+                            launcher,
+                            "resolve_codex_runtime",
+                            side_effect=runtime.RuntimeResolutionError(
+                                "no compatible Codex runtime (path: probe failed)"
+                            ),
+                        ),
+                        mock.patch.object(launcher.subprocess, "run") as start_codex,
+                        redirect_stdout(output),
+                        redirect_stderr(errors),
+                    ):
+                        with self.assertRaises(SystemExit) as raised:
+                            launcher.main()
+
+                    self.assertEqual(raised.exception.code, 1)
+                    start_codex.assert_not_called()
+                    combined = output.getvalue() + errors.getvalue()
+                    self.assertIn("no compatible Codex runtime", combined)
+                    self.assertNotIn(packet, combined)
 
 
 class UserExperienceTests(unittest.TestCase):
@@ -1582,6 +2158,7 @@ class UserExperienceTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            codex_runtime = make_fake_codex_runtime(root)
             native_profiles = root / "agents"
             native_check = subprocess.run(
                 ["sh", str(INSTALL_AGENTS), "--target-dir", str(native_profiles), "--check"],
@@ -1615,6 +2192,7 @@ class UserExperienceTests(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
+                env={**os.environ, "ASTRAL_CODEX_PATH": str(codex_runtime)},
             )
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             evidence = json.loads(result.stdout)

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -127,7 +127,7 @@ class MarketplaceTests(unittest.TestCase):
         manifest = load_json(MANIFEST)
 
         self.assertEqual(manifest["name"], "astral-orchestrator")
-        self.assertEqual(manifest["version"], "3.3.0")
+        self.assertEqual(manifest["version"], "3.3.1")
         self.assertEqual(manifest["license"], "MIT")
         self.assertEqual(manifest["skills"], "./skills/")
         self.assertEqual(manifest["interface"]["displayName"], "Astral Orchestrator")
@@ -171,7 +171,7 @@ class MarketplaceTests(unittest.TestCase):
             "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         )
         self.assertEqual(manifest["name"], "astral-orchestrator")
-        self.assertEqual(manifest["version"], "3.3.0")
+        self.assertEqual(manifest["version"], "3.3.1")
         self.assertEqual(manifest["license"], "MIT")
         self.assertEqual(
             set(manifest),
@@ -2868,7 +2868,7 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
             "--ledger",
             str(RELEASE_LEDGER),
             "--expected-version",
-            "3.3.0",
+            "3.3.1",
             "--format",
             "json",
         )
@@ -2876,13 +2876,14 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         status = json.loads(result.stdout)
         surfaces = status["surfaces"]
-        self.assertEqual(surfaces["source"]["version"], "3.3.0")
+        self.assertEqual(surfaces["source"]["version"], "3.3.1")
+        self.assertEqual(surfaces["source"]["status"], "draft")
         self.assertEqual(surfaces["github_release"]["version"], "3.3.0")
         self.assertEqual(surfaces["github_marketplace"]["version"], "3.3.0")
         self.assertEqual(surfaces["vercel"]["version"], "3.3.0")
         self.assertEqual(surfaces["vercel"]["status"], "deployed")
         self.assertEqual(surfaces["openai_submission"]["version"], "3.3.0")
-        self.assertEqual(surfaces["openai_submission"]["status"], "draft")
+        self.assertEqual(surfaces["openai_submission"]["status"], "approved")
         self.assertEqual(surfaces["openai_directory"]["version"], "3.2.0")
 
     def test_strict_release_check_fails_while_public_directory_lags(self):
@@ -2891,7 +2892,7 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
             "--ledger",
             str(RELEASE_LEDGER),
             "--expected-version",
-            "3.3.0",
+            "3.3.1",
             "--manifest",
             str(MANIFEST),
         )

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -343,11 +343,11 @@ class WebsiteContractTests(unittest.TestCase):
             with self.subTest(phrase=phrase):
                 self.assertIn(phrase, home)
 
-    def test_current_version_copy_is_v3_3_0_on_current_pages(self):
+    def test_current_version_copy_is_v3_3_1_on_current_pages(self):
         for page in ("home", "install", "support"):
             with self.subTest(page=page):
                 content = page_text(PAGES[page])
-                self.assertIn("v3.3.0", content)
+                self.assertIn("v3.3.1", content)
 
     def test_verification_copy_uses_future_proof_test_count(self):
         home = page_text(PAGES["home"])

--- a/website/index.html
+++ b/website/index.html
@@ -59,7 +59,7 @@
       <section class="hero" aria-labelledby="home-title">
         <div class="shell hero-grid">
           <div>
-            <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span>v3.3.0 · open-source · local plugin runtime</p>
+            <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span>v3.3.1 · open-source · local plugin runtime</p>
             <h1 id="home-title">Turn a request into a <span class="gradient-text">checked result.</span></h1>
             <p class="hero-copy">
               Astral Orchestrator gives bigger work a clear route through Codex:

--- a/website/install/index.html
+++ b/website/install/index.html
@@ -58,7 +58,7 @@
         <div class="shell">
           <p class="eyebrow">Quick install</p>
           <h1>Install from GitHub in two commands.</h1>
-          <p class="page-lede">Astral Orchestrator v3.3.0 installs directly from its GitHub marketplace source. This route includes the bundled exact-process launcher, which preserves the pinned Sol, Luna, and Terra model-and-effort contract without requiring native profiles.</p>
+          <p class="page-lede">Astral Orchestrator v3.3.1 installs directly from its GitHub marketplace source. This route includes the bundled exact-process launcher, which preserves the pinned Sol, Luna, and Terra model-and-effort contract without requiring native profiles.</p>
         </div>
       </header>
 

--- a/website/support/index.html
+++ b/website/support/index.html
@@ -58,7 +58,7 @@
         <div class="shell">
           <p class="eyebrow">Support</p>
           <h1>Start with the public project record.</h1>
-          <p class="page-lede">The README explains installation, the v3.3.0 six modes including explicit opt-in Measured, Morph, and Constellation, and common setup questions. The issue tracker is the right place for reproducible bugs, confusing behavior, and improvement ideas.</p>
+          <p class="page-lede">The README explains installation, the v3.3.1 six modes including explicit opt-in Measured, Morph, and Constellation, and common setup questions. The issue tracker is the right place for reproducible bugs, confusing behavior, and improvement ideas.</p>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

- add one shared Codex runtime resolver for exact-process and Morph launchers
- prefer explicit and host runtime hints, then compatible app/runtime candidates, then PATH
- require a bounded `codex features list` configuration/catalog probe before dry-run or inference
- emit sanitized runtime source, version, and probe evidence without exposing paths, configuration, credentials, or worker packets
- document the runtime-selection and OpenCodex boundaries

## Root cause

The launchers previously executed the first `codex` on PATH. When an older standalone CLI preceded the active desktop runtime, it could reject the current OpenCodex catalog schema before inference even though the selected provider/model route was healthy.

## Impact

Astral now selects the first runtime that can parse the user's existing Codex configuration and model catalog. It does not rewrite OpenCodex files, change providers/models, or silently substitute effort or sandbox settings.

## Validation

- test-first regression coverage, including the original PATH/app mismatch
- real fake-executable Morph dry-run fixtures for compatible fallback and all-probes-fail behavior
- Unicode control-character, missing, directory, relative, non-executable, duplicate, and timeout path cases
- macOS, Windows, and Linux candidate generation
- `python3 -m unittest discover -s tests -v`: 133/133 passed
- `sh plugins/astral-orchestrator/scripts/verify.sh`: passed
- Astral skill validator: passed
- release-tracker skill validator: passed
- plugin validator: passed
- read-only local mismatch check selected the ChatGPT app runtime after rejecting the incompatible PATH runtime

## Remaining risk

Executable probing was exercised on macOS/POSIX; Windows and Linux candidate generation is unit-tested but still benefits from native-host confirmation.
