### PR TITLE
Record OpenAI v3.3.1 draft upload

### DIFF
--- a/release/astral-release-ledger.json
+++ b/release/astral-release-ledger.json
@@ -209,6 +209,15 @@
       "evidence": "Production deployment dpl_9JC3mMkmGpuqYACqXeXod7uwwTcL is READY and aliased publicly; a fresh Opera GX accessibility inspection rendered the v3.3.1 badge and six-mode content.",
       "url": "https://astral-orchestrator.vercel.app/",
       "commit": "c8aa07b6191a8758d85b3915f636f2b8c340d837"
+    },
+    {
+      "surface": "openai_submission",
+      "version": "3.3.1",
+      "status": "draft",
+      "observed_at": "2026-08-09T23:13:55+08:00",
+      "evidence": "OpenAI Platform accepted the verified v3.3.1 ZIP with SHA-256 25494575d44b9d3d8335b2a2d780bd71381ecf925eccb40edde08584e711ec6e, created draft appsub_6a7898a502788191ae79a4129034375b, preserved three prompts and six-mode metadata, and saved the approved legal-name and public URLs. Skill scanning remains in progress and all four publisher attestations remain unchecked.",
+      "url": "https://platform.openai.com/plugins/plugins_6a702dc6da648191a24bb8b82093f3cc/submissions/appsub_6a7898a502788191ae79a4129034375b",
+      "commit": "c8aa07b6191a8758d85b3915f636f2b8c340d837"
     }
   ]
 }

--- a/tests/test_astral_orchestrator.py
+++ b/tests/test_astral_orchestrator.py
@@ -2882,8 +2882,8 @@ class ReleaseTrackingSkillTests(unittest.TestCase):
         self.assertEqual(surfaces["github_marketplace"]["version"], "3.3.1")
         self.assertEqual(surfaces["vercel"]["version"], "3.3.1")
         self.assertEqual(surfaces["vercel"]["status"], "deployed")
-        self.assertEqual(surfaces["openai_submission"]["version"], "3.3.0")
-        self.assertEqual(surfaces["openai_submission"]["status"], "approved")
+        self.assertEqual(surfaces["openai_submission"]["version"], "3.3.1")
+        self.assertEqual(surfaces["openai_submission"]["status"], "draft")
         self.assertEqual(surfaces["openai_directory"]["version"], "3.2.0")
 
     def test_strict_release_check_fails_while_public_directory_lags(self):


### PR DESCRIPTION
## Summary

- record the verified v3.3.1 ZIP as an OpenAI Platform draft
- retain independent public-directory status at v3.2.0
- update the release regression test to assert the current OpenAI draft state

## Evidence

- OpenAI draft: `appsub_6a7898a502788191ae79a4129034375b`
- uploaded asset SHA-256: `25494575d44b9d3d8335b2a2d780bd71381ecf925eccb40edde08584e711ec6e`
- version, prompts, six-mode metadata, legal developer name, and public URLs were verified in Opera GX
- all four publisher attestations remain unchecked; skill scanning was still in progress
- `python3 -m unittest discover -s tests -v`: 133/133 passed
- release-tracking skill validator: passed